### PR TITLE
Vendor lists are automatically translated

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
 > - APIs not final
 > - Configuration object not final
 > - UI not final
-> - Vendor list model parsing may be too strict
-> - Some public APIs are missing in ObjC headers
-> - Localization is not implemented, this version leaves this whole topic to the publisher
 >
 > OPEN FOR COMMENT - create a Github issue if you want to participate
 

--- a/demo/SmartCMPDemo/AppDelegate.swift
+++ b/demo/SmartCMPDemo/AppDelegate.swift
@@ -40,7 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CMPConsentManagerDelegate
 
     // MARK: - CMPConsentManagerDelegate
     
-    func consentManagerRequestsToShowConsentTool(_ consentManager: CMPConsentManager) {
+    func consentManagerRequestsToShowConsentTool(_ consentManager: CMPConsentManager, forVendorList vendorList: CMPVendorList) {
         NSLog("CMP Requested ConsentTool Display");
         
         // You should display the consent tool UI, when user is ready

--- a/framework/SmartCMP.xcodeproj/project.pbxproj
+++ b/framework/SmartCMP.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		7E2F052D209CB6A500C8C9E0 /* CMPVendorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2F052C209CB6A500C8C9E0 /* CMPVendorTests.swift */; };
 		7E2F053320A0721900C8C9E0 /* CMPVendorListURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2F053220A0721900C8C9E0 /* CMPVendorListURL.swift */; };
 		7E2F053520A074B800C8C9E0 /* CMPVendorListURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2F053420A074B800C8C9E0 /* CMPVendorListURLTests.swift */; };
+		7E2F053720A0A47400C8C9E0 /* vendors-fr.json in Resources */ = {isa = PBXBuildFile; fileRef = 7E2F053620A0A47300C8C9E0 /* vendors-fr.json */; };
 		7E5A5F752091F8920025BE51 /* CMPVendorListManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5A5F742091F8920025BE51 /* CMPVendorListManagerTests.swift */; };
 		7E5A5F78209228410025BE51 /* CMPConsentString+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5A5F77209228410025BE51 /* CMPConsentString+Utils.swift */; };
 		7E800B512090AEAC001FC83B /* CMPVendorList+JSONKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E800B4C2090AEAC001FC83B /* CMPVendorList+JSONKeys.swift */; };
@@ -100,6 +101,7 @@
 		7E2F052C209CB6A500C8C9E0 /* CMPVendorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPVendorTests.swift; sourceTree = "<group>"; };
 		7E2F053220A0721900C8C9E0 /* CMPVendorListURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPVendorListURL.swift; sourceTree = "<group>"; };
 		7E2F053420A074B800C8C9E0 /* CMPVendorListURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPVendorListURLTests.swift; sourceTree = "<group>"; };
+		7E2F053620A0A47300C8C9E0 /* vendors-fr.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "vendors-fr.json"; sourceTree = "<group>"; };
 		7E5A5F742091F8920025BE51 /* CMPVendorListManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPVendorListManagerTests.swift; sourceTree = "<group>"; };
 		7E5A5F77209228410025BE51 /* CMPConsentString+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMPConsentString+Utils.swift"; sourceTree = "<group>"; };
 		7E800B4C2090AEAC001FC83B /* CMPVendorList+JSONKeys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CMPVendorList+JSONKeys.swift"; sourceTree = "<group>"; };
@@ -268,6 +270,7 @@
 			children = (
 				7EBB616520932BFF00EAD3C7 /* vendors_updated.json */,
 				7E25FC75208F51CF00D05789 /* vendors.json */,
+				7E2F053620A0A47300C8C9E0 /* vendors-fr.json */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -487,6 +490,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7E2F053720A0A47400C8C9E0 /* vendors-fr.json in Resources */,
 				7E25FC7E208F51CF00D05789 /* vendors.json in Resources */,
 				7EBB616620932BFF00EAD3C7 /* vendors_updated.json in Resources */,
 			);

--- a/framework/SmartCMP/CMPConstants.swift
+++ b/framework/SmartCMP/CMPConstants.swift
@@ -35,6 +35,9 @@ internal struct CMPConstants {
     struct VendorList {
         static let DefaultEndPoint                  = "https://vendorlist.consensu.org/vendorlist.json"
         static let VersionedEndPoint                = "https://vendorlist.consensu.org/v-{version}/vendorlist.json"
+        
+        static let DefaultLocalizedEndPoint         = "https://vendorlist.consensu.org/purposes-{language}.json"
+        static let VersionedLocalizedEndPoint       = "https://vendorlist.consensu.org/purposes-{language}-{version}.json"
     }
     
 }

--- a/framework/SmartCMP/Manager/CMPConsentManager.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManager.swift
@@ -243,7 +243,7 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
     private func displayConsentTool(vendorList: CMPVendorList) {
         if let delegate = self.delegate {
             // Publisher will be responsible to trigger consent tool display
-            delegate.consentManagerRequestsToShowConsentTool(self)
+            delegate.consentManagerRequestsToShowConsentTool(self, forVendorList: vendorList)
         } else {
             // Force consent tool display depending on LAT status
             let isTrackingAllowed = ASIdentifierManager.shared().isAdvertisingTrackingEnabled

--- a/framework/SmartCMP/Manager/CMPConsentManager.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManager.swift
@@ -127,7 +127,7 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
         self.showConsentToolIfLAT = showConsentToolIfUserLimitedAdTracking
         
         // Instantiate CPMVendorsManager with URL and RefreshTime and delegate
-        self.vendorListManager = CMPVendorListManager(url: CMPVendorListURL(), refreshInterval: refreshInterval, delegate: self)
+        self.vendorListManager = CMPVendorListManager(url: CMPVendorListURL(language: language), refreshInterval: refreshInterval, delegate: self)
         
         // Check for already existing consent string in NSUserDefaults
         if let storedConsentString = readStringFromUserDefaults(key: CMPConstants.IABConsentKeys.ConsentString) {
@@ -202,7 +202,7 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
             if storedConsentString.vendorListVersion != vendorList.vendorListVersion {
                 // Fetching the old vendor list to migrate the consent string:
                 // Old purposes & vendors must keep their values, new one will be considered as accepted by default
-                vendorListManager.refresh(vendorListURL: CMPVendorListURL(version: storedConsentString.vendorListVersion)) { previousVendorList, error in
+                vendorListManager.refresh(vendorListURL: CMPVendorListURL(version: storedConsentString.vendorListVersion, language: language)) { previousVendorList, error in
                     if let error = error {
                         self.logErrorMessage("CMPConsentManager cannot retrieve previous vendors list because of an error \"\(error.localizedDescription)\"")
                     } else if let previousVendorList = previousVendorList {

--- a/framework/SmartCMP/Manager/CMPConsentManager.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManager.swift
@@ -202,7 +202,7 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
             if storedConsentString.vendorListVersion != vendorList.vendorListVersion {
                 // Fetching the old vendor list to migrate the consent string:
                 // Old purposes & vendors must keep their values, new one will be considered as accepted by default
-                vendorListManager.refresh(vendorListURL: CMPVendorListURL(version: storedConsentString.vendorListVersion, language: language)) { previousVendorList, error in
+                vendorListManager.refresh(vendorListURL: CMPVendorListURL(version: storedConsentString.vendorListVersion)) { previousVendorList, error in
                     if let error = error {
                         self.logErrorMessage("CMPConsentManager cannot retrieve previous vendors list because of an error \"\(error.localizedDescription)\"")
                     } else if let previousVendorList = previousVendorList {

--- a/framework/SmartCMP/Manager/CMPConsentManagerDelegate.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManagerDelegate.swift
@@ -21,9 +21,11 @@ public protocol CMPConsentManagerDelegate : class {
      Called when the consent manager found a reason to display the Consent Tool UI. The publisher should display
      the consent tool has soon as possible.
      
-     - Parameter consentManager: The consent manager instance.
+     - Parameters:
+        - consentManager: The consent manager instance.
+        - vendorList: The vendor list you should ask consent for.
      */
     @objc
-    func consentManagerRequestsToShowConsentTool(_ consentManager: CMPConsentManager)
+    func consentManagerRequestsToShowConsentTool(_ consentManager: CMPConsentManager, forVendorList vendorList: CMPVendorList)
     
 }

--- a/framework/SmartCMP/VendorList/CMPVendor.swift
+++ b/framework/SmartCMP/VendorList/CMPVendor.swift
@@ -37,9 +37,9 @@ public class CMPVendor : NSObject, Codable {
     @objc
     public let features: [Int]
     
-    /// The privacy policy's URL for this vendor.
+    /// The privacy policy's URL for this vendor if any, nil otherwise.
     @objc
-    public let policyURL: URL
+    public let policyURL: URL?
     
     /// A date of deletion of this vendor has been marked as deleted, nil otherwise.
     @objc
@@ -63,7 +63,7 @@ public class CMPVendor : NSObject, Codable {
         - policyURL: The privacy policy's URL for this vendor.
      */
     @objc
-    public convenience init(id: Int, name: String, purposes: [Int], legitimatePurposes: [Int], features: [Int], policyURL: URL) {
+    public convenience init(id: Int, name: String, purposes: [Int], legitimatePurposes: [Int], features: [Int], policyURL: URL?) {
         self.init(id: id, name: name, purposes: purposes, legitimatePurposes: legitimatePurposes, features: features, policyURL: policyURL, deletedDate: nil)
     }
     
@@ -80,7 +80,7 @@ public class CMPVendor : NSObject, Codable {
         - deletedDate: A date of deletion of this vendor has been marked as deleted, nil otherwise.
      */
     @objc
-    public init(id: Int, name: String, purposes: [Int], legitimatePurposes: [Int], features: [Int], policyURL: URL, deletedDate: Date?) {
+    public init(id: Int, name: String, purposes: [Int], legitimatePurposes: [Int], features: [Int], policyURL: URL?, deletedDate: Date?) {
         self.id = id
         self.name = name
         self.purposes = purposes

--- a/framework/SmartCMP/VendorList/CMPVendorList.swift
+++ b/framework/SmartCMP/VendorList/CMPVendorList.swift
@@ -86,6 +86,29 @@ public class CMPVendorList : NSObject, Codable {
      */
     @objc
     public convenience init?(jsonData: Data) {
+        self.init(jsonData: jsonData, localizedJsonData: nil)
+    }
+    
+    /**
+     Initialize a list of vendors from a vendor list JSON (if valid).
+     
+     - Parameters:
+        - jsonData: The data representation of the vendor list JSON.
+        - localizedJsonData: The data representation of the localized vendor list JSON if any.
+     */
+    @objc
+    public convenience init?(jsonData: Data, localizedJsonData: Data?) {
+        
+        // The localized JSON will be used to translate purposes and features if possible, but it is not mandatory. If
+        // some keys are missing in this JSON, or if it's completely invalid, this will not stop the parser.
+        let (localizedPurposesJson, localizedFeaturesJson): ([Any]?, [Any]?) = {
+            if let localizedJsonData = localizedJsonData {
+                let localizedJson = (try? JSONSerialization.jsonObject(with: localizedJsonData)) as? [String: Any]
+                return (localizedJson?[JsonKey.Purposes.PURPOSES] as? [Any], localizedJson?[JsonKey.Features.FEATURES] as? [Any])
+            } else {
+                return (nil, nil)
+            }
+        }()
         
         guard let jsonData = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
             let json = jsonData,
@@ -95,8 +118,8 @@ public class CMPVendorList : NSObject, Codable {
             let purposesJSON = json[JsonKey.Purposes.PURPOSES] as? [Any],
             let featuresJSON = json[JsonKey.Features.FEATURES] as? [Any],
             let vendorsJSON = json[JsonKey.Vendors.VENDORS] as? [Any],
-            let purposes = CMPVendorList.parsePurposes(json: purposesJSON),
-            let features = CMPVendorList.parseFeatures(json: featuresJSON),
+            let purposes = CMPVendorList.parsePurposes(json: purposesJSON, localizedJson: localizedPurposesJson),
+            let features = CMPVendorList.parseFeatures(json: featuresJSON, localizedJson: localizedFeaturesJson),
             let vendors = CMPVendorList.parseVendors(json: vendorsJSON) else {
                 
             return nil // The JSON lacks requires keys and is considered invalid
@@ -192,19 +215,20 @@ public class CMPVendorList : NSObject, Codable {
     /**
      Parse a collection of purposes.
      
-     - Parameter json: A collection of purposes in JSON format.
+     - Parameters:
+        - json: A collection of purposes in JSON format.
+        - localizedJson: A collection of translation for the purposes, if any.
      - Returns: A collection of purposes, or nil if the JSON is invalid.
      */
-    private static func parsePurposes(json: [Any]) -> [CMPPurpose]? {
+    private static func parsePurposes(json: [Any], localizedJson: [Any]?) -> [CMPPurpose]? {
         let result: [CMPPurpose] = json.compactMap { jsonElement in
-            guard let element = jsonElement as? [String: Any],
-                let id = element[JsonKey.Purposes.ID] as? Int,
-                let name = element[JsonKey.Purposes.NAME] as? String,
-                let description = element[JsonKey.Purposes.DESCRIPTION] as? String else {
-                    
-                    return nil  // The JSON lacks requires keys and is considered invalid
+            switch parseJsonElement(jsonElement) {
+            case .some((let id, let name, let description)):
+                let (localizedName, localizedDescription) = nameAndDescription(fromLocalizedJson: localizedJson, forId: id)
+                return CMPPurpose(id: id, name: localizedName ?? name, description: localizedDescription ?? description)
+            default:
+                return nil
             }
-            return CMPPurpose(id: id, name: name, description: description)
         }
         
         return result.count == json.count ? result : nil
@@ -213,22 +237,65 @@ public class CMPVendorList : NSObject, Codable {
     /**
      Parse a collection of features.
      
-     - Parameter json: A collection of features in JSON format.
+     - Parameters:
+        - json: A collection of features in JSON format.
+        - localizedJson: A collection of translation for the features, if any.
      - Returns: A collection of features, or nil if the JSON is invalid.
      */
-    private static func parseFeatures(json: [Any]) -> [CMPFeature]? {
+    private static func parseFeatures(json: [Any], localizedJson: [Any]?) -> [CMPFeature]? {
         let result: [CMPFeature] = json.compactMap { jsonElement in
-            guard let element = jsonElement as? [String: Any],
-                let id = element[JsonKey.Features.ID] as? Int,
-                let name = element[JsonKey.Features.NAME] as? String,
-                let description = element[JsonKey.Features.DESCRIPTION] as? String else {
-                    
-                    return nil  // The JSON lacks requires keys and is considered invalid
+            switch parseJsonElement(jsonElement) {
+            case .some((let id, let name, let description)):
+                let (localizedName, localizedDescription) = nameAndDescription(fromLocalizedJson: localizedJson, forId: id)
+                return CMPFeature(id: id, name: localizedName ?? name, description: localizedDescription ?? description)
+            default:
+                return nil
             }
-            return CMPFeature(id: id, name: name, description: description)
         }
         
         return result.count == json.count ? result : nil
+    }
+    
+    /**
+     Parse a JSON element corresponding to a purpose or a feature if possible.
+     
+     - Parameter jsonElement: The JSON element to be parsed.
+     - Returns: A tuple containing the resulting parsing if successful, nil otherwise.
+     */
+    private static func parseJsonElement(_ jsonElement: Any) -> (Int, String, String)? {
+        guard let element = jsonElement as? [String: Any],
+            let id = element[JsonKey.Purposes.ID] as? Int,
+            let name = element[JsonKey.Purposes.NAME] as? String,
+            let description = element[JsonKey.Purposes.DESCRIPTION] as? String else {
+                return nil  // The JSON lacks requires keys and is considered invalid
+        }
+        
+        return (id, name, description)
+    }
+    
+    /**
+     Retrieve the name and the description of a localized element from the localized JSON and for a given ID.
+     
+     - Parameters:
+        - localizedJson: An optional localized JSON of purposes or features (if nil, this method will return nil for both name & description).
+        - id: The element ID that must be retrieved.
+     - Returns: A tuple containing a name
+     */
+    private static func nameAndDescription(fromLocalizedJson localizedJson: [Any]?, forId id: Int) -> (String?, String?) {
+        if let jsonElements = localizedJson {
+            for jsonElement in jsonElements {
+                if let element = jsonElement as? [String: Any],
+                    let elementId = element[JsonKey.Purposes.ID] as? Int,
+                    elementId == id {
+                    
+                    // Found a JSON element with the right ID: the name and the description can be extracted if possible
+                    return (element[JsonKey.Purposes.NAME] as? String, element[JsonKey.Purposes.DESCRIPTION] as? String)
+                }
+            }
+        }
+        
+        // No element found for the given id, can't extract any info from localized JSON
+        return (nil, nil)
     }
     
     /**

--- a/framework/SmartCMP/VendorList/CMPVendorList.swift
+++ b/framework/SmartCMP/VendorList/CMPVendorList.swift
@@ -244,8 +244,6 @@ public class CMPVendorList : NSObject, Codable {
                 let name = element[JsonKey.Vendors.NAME] as? String,
                 let purposes = element[JsonKey.Vendors.PURPOSE_IDS] as? [Int],
                 let legitimatePurposes = element[JsonKey.Vendors.LEGITIMATE_PURPOSE_IDS] as? [Int],
-                let policyURLString = element[JsonKey.Vendors.POLICY_URL] as? String,
-                let policyURL = URL(string: policyURLString),
                 let features = element[JsonKey.Vendors.FEATURE_IDS] as? [Int] else {
                     
                     return nil  // The JSON lacks requires keys and is considered invalid
@@ -254,6 +252,19 @@ public class CMPVendorList : NSObject, Codable {
             let deletedDate: Date? = {
                 if let deletedDateString = element[JsonKey.Vendors.DELETED_DATE] as? String  {
                     return date(from: deletedDateString)
+                } else {
+                    return nil
+                }
+            }()
+            
+            let policyURL: URL? = {
+                if let policyURLString = element[JsonKey.Vendors.POLICY_URL] as? String,
+                    let policyURL = URL(string: policyURLString),
+                    let policyURLScheme = policyURL.scheme,
+                    policyURLScheme.lowercased() == "http" || policyURLScheme.lowercased() == "https" {
+                    
+                    // A policy url is only considered as valid if it has an HTTP or HTTPS scheme
+                    return policyURL
                 } else {
                     return nil
                 }

--- a/framework/SmartCMP/VendorList/CMPVendorList.swift
+++ b/framework/SmartCMP/VendorList/CMPVendorList.swift
@@ -282,20 +282,17 @@ public class CMPVendorList : NSObject, Codable {
      - Returns: A tuple containing a name
      */
     private static func nameAndDescription(fromLocalizedJson localizedJson: [Any]?, forId id: Int) -> (String?, String?) {
-        if let jsonElements = localizedJson {
-            for jsonElement in jsonElements {
-                if let element = jsonElement as? [String: Any],
-                    let elementId = element[JsonKey.Purposes.ID] as? Int,
-                    elementId == id {
-                    
-                    // Found a JSON element with the right ID: the name and the description can be extracted if possible
-                    return (element[JsonKey.Purposes.NAME] as? String, element[JsonKey.Purposes.DESCRIPTION] as? String)
-                }
+        // Getting name & description for the first element with the right ID
+        let nameAndDescription = localizedJson?.compactMap { jsonElement -> (String?, String?)? in
+            if let element = jsonElement as? [String: Any], let elementId = element[JsonKey.Purposes.ID] as? Int, elementId == id {
+                // Found a JSON element with the right ID: the name and the description can be extracted if possible
+                return (element[JsonKey.Purposes.NAME] as? String, element[JsonKey.Purposes.DESCRIPTION] as? String)
             }
-        }
+            return nil
+        }.first
         
-        // No element found for the given id, can't extract any info from localized JSON
-        return (nil, nil)
+        // Returning the name & description tuple or an empty tuple if the element search failed
+        return nameAndDescription ?? (nil, nil)
     }
     
     /**

--- a/framework/SmartCMP/VendorList/CMPVendorListManager.swift
+++ b/framework/SmartCMP/VendorList/CMPVendorListManager.swift
@@ -232,9 +232,9 @@ internal class CMPVendorListManager {
      Fetch a vendor list from a raw URL using a dispatch group for synchronization.
      
      - Parameters:
-     - dispatchGroup:
-     - url:
-     - responseHandler:
+        - dispatchGroup: The dispatch group that is going to be locked during the request.
+        - url: The raw URL that need to be fetched
+        - responseHandler: The callback that will be called when the request finished.
      */
     private func fetchVendorList(withDispatchGroup dispatchGroup: DispatchGroup, url: URL, responseHandler: @escaping (Data?, Error?) -> ()) {
         dispatchGroup.enter()

--- a/framework/SmartCMP/VendorList/CMPVendorListManager.swift
+++ b/framework/SmartCMP/VendorList/CMPVendorListManager.swift
@@ -242,7 +242,6 @@ internal class CMPVendorListManager {
             responseHandler(data, error)
             dispatchGroup.leave()
         }
-        
     }
     
     /**

--- a/framework/SmartCMP/VendorList/CMPVendorListManager.swift
+++ b/framework/SmartCMP/VendorList/CMPVendorListManager.swift
@@ -172,9 +172,8 @@ internal class CMPVendorListManager {
         refreshHandler?(lastRefreshDate) // calling handler when refreshing for unit testing purposes only
         
         fetchVendorList(vendorListURL: vendorListURL) { (vendorListData, vendorListError, localizedVendorListData, localizedVendorListError) in
-            // TODO handle the case where a localized vendor list is available
             if let vendorListData = vendorListData, vendorListError == nil {
-                if let vendorList = CMPVendorList(jsonData: vendorListData) {
+                if let vendorList = CMPVendorList(jsonData: vendorListData, localizedJsonData: localizedVendorListData) {
                     self.lastRefreshDate = Date()
                     
                     // Fetching successful

--- a/framework/SmartCMP/VendorList/CMPVendorListURL.swift
+++ b/framework/SmartCMP/VendorList/CMPVendorListURL.swift
@@ -19,25 +19,50 @@ internal class CMPVendorListURL {
     /// The actual url of the vendor list.
     let url: URL
     
+    /// The actual localized url of the vendor list if any.
+    let localizedUrl: URL?
+    
     /**
      Initialize a CMPVendorListURL object that represents the latest vendor list.
+     
+     - Parameter language: The language of the user if a localized url has to be used.
      */
-    init() {
+    init(language: CMPLanguage? = nil) {
         url = URL(string: CMPConstants.VendorList.DefaultEndPoint)!
+        
+        localizedUrl = {
+            if let language = language {
+                let urlString = CMPConstants.VendorList.DefaultLocalizedEndPoint
+                    .replacingOccurrences(of: "{language}", with: language.string)
+                return URL(string: urlString)
+            }
+            return nil
+        }()
     }
     
     /**
      Initialize a CMPVendorListURL object that representsthe vendor list for a given version.
      
-     - Parameter version:
+     - Parameters:
+        - version: The vendor list version that should be fetched.
+        - language: The language of the user if a localized url has to be used.
      */
-    init(version: Int) {
+    init(version: Int, language: CMPLanguage? = nil) {
         precondition(version >= 0, "Version number must be a positive number!")
         
         let urlString = CMPConstants.VendorList.VersionedEndPoint
             .replacingOccurrences(of: "{version}", with: String(version))
-        
         url = URL(string: urlString)!
+        
+        localizedUrl = {
+            if let language = language {
+                let urlString = CMPConstants.VendorList.VersionedLocalizedEndPoint
+                    .replacingOccurrences(of: "{language}", with: language.string)
+                    .replacingOccurrences(of: "{version}", with: String(version))
+                return URL(string: urlString)
+            }
+            return nil
+        }()
     }
     
 }

--- a/framework/SmartCMPTests/Resources/vendors-fr.json
+++ b/framework/SmartCMPTests/Resources/vendors-fr.json
@@ -1,0 +1,30 @@
+{
+	"vendorListVersion": 6,
+	"lastUpdated": "2018-04-23T16:03:22Z",
+	"purposes": [{
+		"id": 1,
+		"name": "Purpose 1 name translated in french",
+		"description": "Purpose 1 description translated in french"
+	}, {
+		"id": 2,
+		"name": "Purpose 2 name translated in french",
+		"description": "Purpose 2 description translated in french"
+	}, {
+		"id": 3,
+		"name": "Purpose 3 name translated in french",
+		"description": "Purpose 3 description translated in french"
+	}, {
+		"id": 5,
+		"name": "Purpose 5 name translated in french",
+		"description": "Purpose 5 description translated in french"
+	}],
+	"features": [{
+		"id": 1,
+		"name": "Feature 1 name translated in french",
+		"description": "Feature 1 description translated in french"
+	}, {
+		"id": 2,
+		"name": "Feature 2 name translated in french",
+		"description": "Feature 2 description translated in french"
+	}]
+}

--- a/framework/SmartCMPTests/VendorList/CMPVendorListTests.swift
+++ b/framework/SmartCMPTests/VendorList/CMPVendorListTests.swift
@@ -21,15 +21,18 @@ class CMPVendorListTests : XCTestCase {
         return  formatter.date(from: string)!
     }
     
-    // Loading a sample JSON for unit testing
     private lazy var vendorsJSON: Data = {
         let url = Bundle(for: type(of: self)).url(forResource: "vendors", withExtension: "json")!
         return try! Data(contentsOf: url)
     }()
     
-    // Loading a sample JSON for unit testing
     private lazy var updatedVendorsJSON: Data = {
         let url = Bundle(for: type(of: self)).url(forResource: "vendors_updated", withExtension: "json")!
+        return try! Data(contentsOf: url)
+    }()
+    
+    private lazy var vendorsFRJSON: Data = {
+        let url = Bundle(for: type(of: self)).url(forResource: "vendors-fr", withExtension: "json")!
         return try! Data(contentsOf: url)
     }()
     
@@ -114,6 +117,63 @@ class CMPVendorListTests : XCTestCase {
         XCTAssertNotNil(decodedVendorList)
         
         XCTAssertEqual(vendorList, decodedVendorList)
+    }
+    
+    func testVendorListCannotBeCreatedFromTranslatedListOnly() {
+        let vendorList = CMPVendorList(jsonData: self.vendorsFRJSON)
+        XCTAssertNil(vendorList)
+    }
+    
+    func testVendorListCanBeLocalizedWithAnExternalJson() {
+        let vendorList = CMPVendorList(jsonData: self.vendorsJSON, localizedJsonData: self.vendorsFRJSON)
+        
+        XCTAssertNotNil(vendorList)
+        XCTAssertEqual(vendorList?.vendorListVersion, 6)
+        XCTAssertEqual(vendorList?.lastUpdated, date(from: "2018-04-23T16:03:22Z"))
+        
+        XCTAssertEqual(vendorList?.purposes.count, 5)
+        XCTAssertEqual(vendorList?.purposes[2].id, 3)
+        XCTAssertEqual(vendorList?.purposes[2].name, "Purpose 3 name translated in french")
+        XCTAssertEqual(vendorList?.purposes[2].purposeDescription, "Purpose 3 description translated in french")
+        
+        XCTAssertEqual(vendorList?.features.count, 3)
+        XCTAssertEqual(vendorList?.features[1].id, 2)
+        XCTAssertEqual(vendorList?.features[1].name, "Feature 2 name translated in french")
+        XCTAssertEqual(vendorList?.features[1].featureDescription, "Feature 2 description translated in french")
+        
+        XCTAssertEqual(vendorList?.vendors.count, 17)
+        XCTAssertEqual(vendorList?.vendors[4].id, 27)
+        XCTAssertEqual(vendorList?.vendors[4].name, "ADventori SAS")
+        XCTAssertEqual(vendorList?.vendors[4].policyURL, URL(string: "https://www.adventori.com/with-us/legal-notice/"))
+        XCTAssertEqual(vendorList?.vendors[4].purposes, [2])
+        XCTAssertEqual(vendorList?.vendors[4].legitimatePurposes, [1, 3, 4, 5])
+        XCTAssertEqual(vendorList?.vendors[4].features, [])
+    }
+    
+    func testVendorListWithInvalidLocalizedJsonFallbackOnDefaultValues() {
+        let vendorList = CMPVendorList(jsonData: self.vendorsJSON, localizedJsonData: "{}".data(using: String.Encoding.utf8)!) // Empty localized JSON
+        
+        XCTAssertNotNil(vendorList)
+        XCTAssertEqual(vendorList?.vendorListVersion, 6)
+        XCTAssertEqual(vendorList?.lastUpdated, date(from: "2018-04-23T16:03:22Z"))
+        
+        XCTAssertEqual(vendorList?.purposes.count, 5)
+        XCTAssertEqual(vendorList?.purposes[2].id, 3)
+        XCTAssertEqual(vendorList?.purposes[2].name, "Ad selection, delivery, reporting")
+        XCTAssertEqual(vendorList?.purposes[2].purposeDescription, "The collection of information, and combination with previously collected information, to select and deliver advertisements for you, and to measure the delivery and effectiveness of such advertisements. This includes using previously collected information about your interests to select ads, processing data about what advertisements were shown, how often they were shown, when and where they were shown, and whether you took any action related to the advertisement, including for example clicking an ad or making a purchase. ")
+        
+        XCTAssertEqual(vendorList?.features.count, 3)
+        XCTAssertEqual(vendorList?.features[1].id, 2)
+        XCTAssertEqual(vendorList?.features[1].name, "Linking Devices")
+        XCTAssertEqual(vendorList?.features[1].featureDescription, "Allow processing of a user's data to connect such user across multiple devices.")
+        
+        XCTAssertEqual(vendorList?.vendors.count, 17)
+        XCTAssertEqual(vendorList?.vendors[4].id, 27)
+        XCTAssertEqual(vendorList?.vendors[4].name, "ADventori SAS")
+        XCTAssertEqual(vendorList?.vendors[4].policyURL, URL(string: "https://www.adventori.com/with-us/legal-notice/"))
+        XCTAssertEqual(vendorList?.vendors[4].purposes, [2])
+        XCTAssertEqual(vendorList?.vendors[4].legitimatePurposes, [1, 3, 4, 5])
+        XCTAssertEqual(vendorList?.vendors[4].features, [])
     }
     
 }

--- a/framework/SmartCMPTests/VendorList/CMPVendorListTests.swift
+++ b/framework/SmartCMPTests/VendorList/CMPVendorListTests.swift
@@ -59,6 +59,14 @@ class CMPVendorListTests : XCTestCase {
         XCTAssertEqual(vendorList?.vendors[4].features, [])
     }
     
+    func testInvalidPolicyURLAreRejectedByTheParser() {
+        let vendorList = CMPVendorList(jsonData: self.vendorsJSON)
+        XCTAssertNotNil(vendorList)
+        
+        XCTAssertEqual(vendorList?.vendors[12].name, "ADITION technologies AG")
+        XCTAssertNil(vendorList?.vendors[12].policyURL) // 'adition.com/datenschutz' is not valid because a scheme is needed
+    }
+    
     func testEmptyJSONIsRejectedByTheParser() {
         let vendorList1 = CMPVendorList(jsonData: "".data(using: String.Encoding.utf8)!)
         XCTAssertNil(vendorList1)

--- a/framework/SmartCMPTests/VendorList/CMPVendorListURLTests.swift
+++ b/framework/SmartCMPTests/VendorList/CMPVendorListURLTests.swift
@@ -17,11 +17,27 @@ class CMPVendorListURLTests : XCTestCase {
     func testDefaultVendorListURLCorrespondsToTheLatest() {
         let expectedUrl = URL(string: "https://vendorlist.consensu.org/vendorlist.json")!
         XCTAssertEqual(CMPVendorListURL().url, expectedUrl)
+        XCTAssertNil(CMPVendorListURL().localizedUrl)
     }
     
     func testVendorListURLCanCorrespondToSpecificVersion() {
         let expectedUrl = URL(string: "https://vendorlist.consensu.org/v-42/vendorlist.json")!
         XCTAssertEqual(CMPVendorListURL(version: 42).url, expectedUrl)
+        XCTAssertNil(CMPVendorListURL(version: 42).localizedUrl)
+    }
+    
+    func testDefaultVendorListSupportLocalization() {
+        let expectedUrl = URL(string: "https://vendorlist.consensu.org/vendorlist.json")!
+        let expectedLocalizedUrl = URL(string: "https://vendorlist.consensu.org/purposes-fr.json")!
+        XCTAssertEqual(CMPVendorListURL(language: CMPLanguage(string: "fr")!).url, expectedUrl)
+        XCTAssertEqual(CMPVendorListURL(language: CMPLanguage(string: "fr")!).localizedUrl, expectedLocalizedUrl)
+    }
+    
+    func testVersionSpecificVendorListSupportLocalization() {
+        let expectedUrl = URL(string: "https://vendorlist.consensu.org/v-42/vendorlist.json")!
+        let expectedLocalizedUrl = URL(string: "https://vendorlist.consensu.org/purposes-fr-42.json")!
+        XCTAssertEqual(CMPVendorListURL(version: 42, language: CMPLanguage(string: "fr")!).url, expectedUrl)
+        XCTAssertEqual(CMPVendorListURL(version: 42, language: CMPLanguage(string: "fr")!).localizedUrl, expectedLocalizedUrl)
     }
     
 }


### PR DESCRIPTION
Vendor lists fetched from the IAB website might have some translation JSON associated with the user's language.
In this case, the vendor list will be merged with the translation before being presented to the user.
If no translation is available, the default labels will be used instead like before.