### PR TITLE
Proper iOS 'Limited Ad Tracking' behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The current version of _SmartCMP_ has the following limitations:
 * The consent tool UI is not customizable (except for static texts). You can however build your own UI and display it in the ```consentManagerRequestsToShowConsentTool``` delegate method using the ```vendorList``` parameter.
 * _AppleTV_ apps are not supported.
 * The IAB specification allows publishers to display only a subset of purposes & vendors using a _pubvendors.json_ file, stored on their own infrastructure. _SmartCMP_ does not implement this feature at this time.
+* No static texts are provided by default (you must provide them to ```CMPConsentToolConfiguration```). The ```homeScreenText``` should be validated by your legal department.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,12 @@
 # SmartCMP for iOS
 
-> WORK IN PROGRESS: DO NOT USE IN PRODUCTION!
->
-> - APIs not final
-> - Configuration object not final
-> - UI not final
->
-> OPEN FOR COMMENT - create a Github issue if you want to participate
-
 ## Introduction
 
-_SmartCMP_ is a framework allowing you to retrieve and store the user's consent for data usage in your iOS apps.
+_SmartCMP for iOS_ is a iOS framework allowing you to retrieve and store the user's consent for data usage in your iOS apps.
 
-Retrieving user consent will be mandatory in EU starting May 25th due to the _General Data Protection Regulation (GDPR)_.
+The purposes & vendors retrieval as well as the consent storage is compliant with [IAB Transparency and Consent Framework specifications](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework).
+
+Retrieving user consent is mandatory in EU starting May 25th due to the _General Data Protection Regulation (GDPR)_.
 
 <p align="center">
   <img src="images/ios-consent-tool.gif" alt="Consent tool on iOS"/>
@@ -29,7 +23,7 @@ Drag the ```SmartCMP.xcodeproj``` to your project and add the ```SmartCMP.framew
 You must setup the CMP before using it. Start by creating a configuration object that will define how the first screen of the consent tool will look like:
 
     let config = CMPConsentToolConfiguration(logo: UIImage(named: "logo")!,
-                                           homeScreenText: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+                                           homeScreenText: "[Place here your legal privacy notice for the consent tool, compliant with GDPR]",
                                            homeScreenManageConsentButtonTitle: "MANAGE MY CHOICES",
                                            homeScreenCloseButtonTitle: "GOT IT, THANKS!",
                                            consentManagementScreenTitle: "Privacy preferences",
@@ -37,17 +31,18 @@ You must setup the CMP before using it. Start by creating a configuration object
                                            consentManagementSaveButtonTitle: "Save",
                                            consentManagementScreenVendorsSectionHeaderText: "Vendors",
                                            consentManagementScreenPurposeSectionHeaderText: "Purpose",
-                                           consentManagementVendorsControllerAccessText: "Customize authorized vendors",
+                                           consentManagementVendorsControllerAccessText: "Authorized vendors",
                                            consentManagementActivatedText: "yes",
                                            consentManagementDeactivatedText: "no",
                                            consentManagementPurposeDetailAllowText: "Allowed",
                                            consentManagementVendorDetailViewPolicyText: "View privacy policy",
                                            consentManagementVendorDetailPurposesText: "Required purposes",
+                                           consentManagementVendorDetailLegitimatePurposesText: "Legitimate interest purposes",
                                            consentManagementVendorDetailFeaturesText: "Features")
 
 Call the ```configure()``` method on ```CMPConsentManager.shared``` to start the CMP.
 
-    CMPConsentManager.shared.configure(language: CMPLanguage(string: "en")!, consentToolConfiguration: self.generateConsentToolConfiguration())
+    CMPConsentManager.shared.configure(language: CMPLanguage.DEFAULT_LANGUAGE, consentToolConfiguration: self.generateConsentToolConfiguration())
 
 When the CMP is started, it will automatically fetch the most recent vendors list _(vendors.json)_ and prompt the user for consent if necessary, saving the resulting consent string in iOS _NSUserDefaults_ (according to the IAB specifications).
 
@@ -58,13 +53,27 @@ You might want to control when the user will be prompted for consent for better 
 When retrieval of the user consent is required, the ```consentManagerRequestsToShowConsentTool```
  method will be called on the delegate and it will be the app's responsability to display the consent tool UI when appropriate.
 
-    func consentManagerRequestsToShowConsentTool(_ consentManager: CMPConsentManager) {
-      // It is necessary to update the user consent using the consent tool.
+    func consentManagerRequestsToShowConsentTool(_ consentManager: CMPConsentManager, forVendorList vendorList: CMPVendorList) {
+      // It is necessary to update the user consent using the consent tool or your own UI
     }
 
 Showing the consent tool is done using the method ```showConsentTool```. Note that this method can be used not only when it has been requested by the consent manager, but also anytime you want to provide a way for the user to change its consent options.
 
     CMPConsentManager.shared.showConsentTool(fromController: self)
+
+## 'Limited Ad Tracking' behavior
+
+On iOS, the user can opt out for any tracking related to advertisement by enabling 'Limited Ad Tracking' in the OS settings. By default, the CMP does not handle this option and let the app developer choose how he wants to proceed if it has been enabled by the user. **Please note that not handling the 'Limited Ad Tracking' option properly is a violation of Apple App Store's terms & conditions. Your app might be removed from the store.**
+
+However, if you configure the CMP with the parameter ```showConsentToolWhenLimitedAdTracking``` set to _false_, it will handle the 'Limited Ad Tracking' option automatically. In case of limited ad tracking the CMP will not display the consent tool and will not call the delegate, but will instead store a consent string with no consent given for any purposes or vendors.
+
+## Known limitations
+
+The current version of _SmartCMP_ has the following limitations:
+
+* The consent tool UI is not customizable (except for static texts). You can however build your own UI and display it in the ```consentManagerRequestsToShowConsentTool``` delegate method using the ```vendorList``` parameter.
+* _AppleTV_ apps are not supported.
+* The IAB specification allows publishers to display only a subset of purposes & vendors using a _pubvendors.json_ file, stored on their own infrastructure. _SmartCMP_ does not implement this feature at this time.
 
 ## License
 

--- a/demo/SmartCMPDemo/AppDelegate.swift
+++ b/demo/SmartCMPDemo/AppDelegate.swift
@@ -45,10 +45,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CMPConsentManagerDelegate
     func consentManagerRequestsToShowConsentTool(_ consentManager: CMPConsentManager, forVendorList vendorList: CMPVendorList) {
         NSLog("CMP Requested ConsentTool Display");
         
-        // You should display the consent tool UI, when user is ready
+        // You should display the consent tool UI, when user is ready…
         if let controller = self.window?.rootViewController {
             consentManager.showConsentTool(fromController: controller)
         }
+        
+        // Since the vendor list is provided in parameter of this delegate method, you can also build your own UI to ask for
+        // user consent and simply save the resulting consent string in the relevant IAB keys (see the IAB specification for
+        // more details about this).
+        //
+        // To generate a valid IAB consent string easily, you can use the CMPConsentString class.
     }
     
     // MARK: - Consent Tool Configuration
@@ -71,6 +77,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CMPConsentManagerDelegate
                                            consentManagementVendorDetailPurposesText: "Required purposes",
                                            consentManagementVendorDetailLegitimatePurposesText: "Legitimate interest purposes",
                                            consentManagementVendorDetailFeaturesText: "Features")
+        
+
     }
     
 }

--- a/framework/SmartCMP/ConsentString/CMPConsentString+Decoding.swift
+++ b/framework/SmartCMP/ConsentString/CMPConsentString+Decoding.swift
@@ -159,6 +159,11 @@ internal extension CMPConsentString {
         if let defaultValue = CMPBitUtils.bitsToBool(buffer.pop(numberOfBits: versionConfig.defaultConsentBitSize)),
             let numEntries = CMPBitUtils.bitsToInt(buffer.pop(numberOfBits: versionConfig.numEntriesBitSize)) {
             
+            // Nothing to do if numEntries is equal to zero: there is no vendors allowed
+            guard numEntries > 0 else {
+                return []
+            }
+            
             var vendors: [Int] = []
             
             // Converting every range into an array of vendor id

--- a/framework/SmartCMP/Manager/CMPConsentManager.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManager.swift
@@ -254,20 +254,20 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
         // Checking the 'Limited Ad Tracking' status of the device
         let isTrackingAllowed = ASIdentifierManager.shared().isAdvertisingTrackingEnabled
         
-        // If the 'Limited Ad Tracking' is disable on the device, or if the 'Limited Ad Tracking' is enable but the publisher
-        // wants to handle it itself…
-        if isTrackingAllowed || (!isTrackingAllowed && self.showConsentToolIfLAT) {
+        // If the 'Limited Ad Tracking' is disabled on the device, or if the 'Limited Ad Tracking' is enabled but the publisher
+        // wants to handle this option himself…
+        if isTrackingAllowed || self.showConsentToolIfLAT {
             if let delegate = self.delegate {
                 // The delegate is called so the publisher can ask for user's consent
                 delegate.consentManagerRequestsToShowConsentTool(self, forVendorList: vendorList)
             } else {
-                // There is no delegate so the CMP asked for user's consent automatically
+                // There is no delegate so the CMP will ask for user's consent automatically
                 if let viewController = UIApplication.shared.keyWindow?.rootViewController {
                     showConsentTool(fromController: viewController)
                 }
             }
         } else {
-            // If 'Limited Ad Tracking' is enabled and the publisher don't want to handle it itself, a consent string with no
+            // If 'Limited Ad Tracking' is enabled and the publisher don't want to handle it himself, a consent string with no
             // consent (for all vendors / purposes) is generated and stored.
             self.consentString = CMPConsentString.consentStringWithNoConsent(consentScreen: 0, consentLanguage: self.language, vendorList: vendorList, date: Date())
         }

--- a/framework/SmartCMP/Manager/CMPConsentManager.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManager.swift
@@ -91,25 +91,29 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
             refreshInterval: CMPConsentManager.DEFAULT_VENDORLIST_REFRESH_TIME,
             language: language,
             consentToolConfiguration: consentToolConfiguration,
-            showConsentToolIfUserLimitedAdTracking: CMPConsentManager.DEFAULT_LAT_VALUE
+            showConsentToolWhenLimitedAdTracking: CMPConsentManager.DEFAULT_LAT_VALUE
         )
     }
     
     /**
      Configure the CMPConsentManager. This method must be called only once per session.
      
+     Note: if you set 'showConsentToolWhenLimitedAdTracking' to true, you will be able to ask for user consent even if 'Limited Ad
+     Tracking' has been enabled on the device. In this case, remember that you still have to comply to Apple's App Store Terms and
+     Conditions regarding 'Limited Ad Tracking'.
+     
      - Parameters:
         - vendorListURL: The URL from where to fetch the vendor list (vendors.json). If you enter your own URL, your custom list MUST BE compatible with IAB specifications and respect vendorId and purposeId distributed by the IAB.
         - refreshInterval: The interval in seconds to refresh the vendor list.
         - language: an instance of CMPLanguage reflecting the device's current language.
         - consentToolConfiguration: an instance of CMPConsentToolConfiguration to configure of the consent tool UI.
-        - showConsentToolIfUserLimitedAdTracking: Whether or not the consent tool UI should be shown if user's checked Limit Ad Tracking in his device's preferences. If false, UI will never be shown if user checked LAT and consent string will be formatted has "user does not give consent".
+        - showConsentToolWhenLimitedAdTracking: Whether or not the consent tool UI should be shown if the user has enabled 'Limit Ad Tracking' in his device's preferences. If false, the consent tool will never be shown if user has enabled 'Limit Ad Tracking' and the consent string will be formatted has 'user does not give consent'. Note that if you have provided a delegate, it will not be called either.
      */
     @objc
     public func configure(refreshInterval: TimeInterval = CMPConsentManager.DEFAULT_VENDORLIST_REFRESH_TIME,
                           language: CMPLanguage,
                           consentToolConfiguration: CMPConsentToolConfiguration,
-                          showConsentToolIfUserLimitedAdTracking: Bool = CMPConsentManager.DEFAULT_LAT_VALUE) {
+                          showConsentToolWhenLimitedAdTracking: Bool = CMPConsentManager.DEFAULT_LAT_VALUE) {
         // Check that we did not already configure, log error and stop if already configured
         if self.configured {
             logErrorMessage("CMPConsentManager is already configured for this session. You cannot reconfigure.")
@@ -124,7 +128,7 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
         
         // Consent Tool
         self.consentToolConfiguration = consentToolConfiguration
-        self.showConsentToolIfLAT = showConsentToolIfUserLimitedAdTracking
+        self.showConsentToolIfLAT = showConsentToolWhenLimitedAdTracking
         
         // Instantiate CPMVendorsManager with URL and RefreshTime and delegate
         self.vendorListManager = CMPVendorListManager(url: CMPVendorListURL(language: language), refreshInterval: refreshInterval, delegate: self)

--- a/framework/SmartCMP/Manager/CMPConsentManagerDelegate.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManagerDelegate.swift
@@ -21,6 +21,10 @@ public protocol CMPConsentManagerDelegate : class {
      Called when the consent manager found a reason to display the Consent Tool UI. The publisher should display
      the consent tool as soon as possible.
      
+     Note: this delegate will never be called if 'showConsentToolWhenLimitedAdTracking=false' is used during the CMPConsentManager
+     configuration and if the user has enabled 'Limited Ad Tracking' in its iOS preferences. In this case, a consent string without
+     any consent will be automatically generated and stored.
+     
      - Parameters:
         - consentManager: The consent manager instance.
         - vendorList: The vendor list you should ask consent for.

--- a/framework/SmartCMPTests/ConsentString/CMPConsentStringTests.swift
+++ b/framework/SmartCMPTests/ConsentString/CMPConsentStringTests.swift
@@ -166,6 +166,50 @@ class CMPConsentStringTests : XCTestCase {
         XCTAssertEqual(consentString.consentString, "BOEFBi5OEFBi5ABACDENABwAAAAAaACgACAAQABA")
     }
     
+    func testEmptyConsentStringEncodingWithBitfieldAndDecoded() {
+        let date = self.date(from: "2017-11-07T18:59:04.9Z")
+        
+        let consentString = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
+                                             created: date,
+                                             lastUpdated: date,
+                                             cmpId: 1,
+                                             cmpVersion: 2,
+                                             consentScreen: 3,
+                                             consentLanguage: CMPLanguage(string: "en")!,
+                                             vendorListVersion: 1,
+                                             maxVendorId: 6,
+                                             allowedPurposes: [],
+                                             allowedVendors: [],
+                                             vendorListEncoding: .bitfield)
+        
+        let resultString = CMPConsentString.from(base64: consentString.consentString)
+        
+        XCTAssertNotNil(resultString)
+        XCTAssertEqual(consentString, resultString)
+    }
+    
+    func testEmptyConsentStringEncodingWithRangeAndDecoded() {
+        let date = self.date(from: "2017-11-07T18:59:04.9Z")
+        
+        let consentString = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
+                                             created: date,
+                                             lastUpdated: date,
+                                             cmpId: 1,
+                                             cmpVersion: 2,
+                                             consentScreen: 3,
+                                             consentLanguage: CMPLanguage(string: "en")!,
+                                             vendorListVersion: 1,
+                                             maxVendorId: 6,
+                                             allowedPurposes: [],
+                                             allowedVendors: [],
+                                             vendorListEncoding: .range)
+        
+        let resultString = CMPConsentString.from(base64: consentString.consentString)
+        
+        XCTAssertNotNil(resultString)
+        XCTAssertEqual(consentString, resultString)
+    }
+    
     func testConsentStringEncodingWithBitfieldAndUnorderedArrays() {
         let date = self.date(from: "2017-11-07T18:59:04.9Z")
         


### PR DESCRIPTION
This pull request implements a proper (and documented) behavior for the CMP when the iOS 'Limited Ad Tracking' option is enabled by the user.
It also fixes a potential crash when decoding consent strings in which no consent has been given for any vendors.