### PR TITLE
Using proper SmartCMP ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ Check the [LICENSE file](LICENSE) for more details.
 
 The CMP ID _'33'_ used for consent string encoding is the CMP ID of _Smart AdServer_.
 
-You can use this CMP ID as long as you don't alter the source code of _SmartCMP_. If you do modify the source code, **YOU MUST REGISTER YOUR FORK AS A NEW CMP and change the CMP ID** in ```CMPConstants.CMPInfos.ID```. You can register your fork CMP and obtain your own ID here: https://register.consensu.org/CMP
+You can use this CMP ID as long as you don't alter the source code of _SmartCMP_. If you do modify the source code, **YOU MUST REGISTER YOUR FORK AS A NEW CMP and change the CMP ID** in ```CMPConstants.CMPInfos.ID```. You can register your forked eCMP and obtain your own ID here: https://register.consensu.org/CMP

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ The current version of _SmartCMP_ has the following limitations:
 
 ## License
 
+### Code source licensing
+
 This software is distributed under the _Creative Commons Legal Code, Attribution 3.0 Unported_ license.
 
 Check the [LICENSE file](LICENSE) for more details.
+
+### Reusing SmartCMP ID
+
+The CMP ID _'33'_ used for consent string encoding is the CMP ID of _Smart AdServer_.
+
+You can use this CMP ID as long as you don't alter the source code of _SmartCMP_. If you do modify the source code, **YOU MUST REGISTER YOUR FORK AS A NEW CMP and change the CMP ID** in ```CMPConstants.CMPInfos.ID```. You can register your fork CMP and obtain your own ID here: https://register.consensu.org/CMP

--- a/framework/SmartCMP/CMPConstants.swift
+++ b/framework/SmartCMP/CMPConstants.swift
@@ -18,8 +18,11 @@ internal struct CMPConstants {
     
     /// Generic information on the CMP framework
     struct CMPInfos {
-        static let ID = 42
         static let VERSION = 1
+        static let ID = 33  // '33' IS THE OFFICIAL CMP ID FOR SmartCMP.
+                            // You can use this ID as long as you don't change the source code of this project.
+                            // If you don't use it exactly as distributed in the official Smart AdServer repository,
+                            // you must get your own CMP ID by registering here: https://register.consensu.org/CMP
     }
     
     /// IAB Keys for NSUserDefault storage

--- a/framework/SmartCMP/ConsentString/CMPConsentString+Utils.swift
+++ b/framework/SmartCMP/ConsentString/CMPConsentString+Utils.swift
@@ -28,9 +28,9 @@ internal extension CMPConsentString {
      - Returns: A new consent string with no consent given.
      */
     static func consentStringWithNoConsent(consentScreen: Int,
-                                             consentLanguage: CMPLanguage,
-                                             vendorList: CMPVendorList,
-                                             date: Date = Date()) -> CMPConsentString {
+                                           consentLanguage: CMPLanguage,
+                                           vendorList: CMPVendorList,
+                                           date: Date = Date()) -> CMPConsentString {
         
         return CMPConsentString(
             versionConfig: CMPVersionConfig.LATEST,
@@ -85,12 +85,14 @@ internal extension CMPConsentString {
         - updatedVendorList: The updated vendor list.
         - previousVendorList: The previous consent string that has been used to generated the previous consent string.
         - previousConsentString: The previous consent string.
+        - consentLanguage: The language that the CMP asked for consent in.
         - lastUpdated: The date that will be used as last updated date (optional, it will use the current date by default).
      - Returns: The new consent string.
      */
     static func consentString(fromUpdatedVendorList updatedVendorList: CMPVendorList,
                               previousVendorList: CMPVendorList,
                               previousConsentString: CMPConsentString,
+                              consentLanguage: CMPLanguage,
                               lastUpdated: Date = Date()) -> CMPConsentString {
         
         let updatedAllowedPurposes = IndexSet((1...updatedVendorList.purposes.count).compactMap { index in
@@ -113,10 +115,10 @@ internal extension CMPConsentString {
             versionConfig: CMPVersionConfig.LATEST,
             created: previousConsentString.created,
             lastUpdated: lastUpdated,
-            cmpId: previousConsentString.cmpId,
-            cmpVersion: previousConsentString.cmpVersion,
+            cmpId: CMPConstants.CMPInfos.ID,
+            cmpVersion: CMPConstants.CMPInfos.VERSION,
             consentScreen: previousConsentString.consentScreen,
-            consentLanguage: previousConsentString.consentLanguage,
+            consentLanguage: consentLanguage,
             allowedPurposes: updatedAllowedPurposes,
             allowedVendors: updatedAllowedVendors,
             vendorList: updatedVendorList
@@ -131,11 +133,13 @@ internal extension CMPConsentString {
      - Parameters:
         - purposeId: The purpose id which should be added to the consent list.
         - consentString: The consent string which should be copied.
+        - consentLanguage: The language that the CMP asked for consent in.
         - lastUpdated: The date that will be used as last updated date (optional, it will use the current date by default).
      - Returns: A new consent string with a consent given for a particular purpose.
      */
     static func consentStringByAddingConsent(forPurposeId purposeId: Int,
                                              consentString: CMPConsentString,
+                                             consentLanguage: CMPLanguage,
                                              lastUpdated: Date = Date()) -> CMPConsentString {
         
         let updatedAllowedPurposes = !consentString.allowedPurposes.contains(purposeId) ?
@@ -145,10 +149,10 @@ internal extension CMPConsentString {
             versionConfig: CMPVersionConfig.LATEST,
             created: consentString.created,
             lastUpdated: lastUpdated,
-            cmpId: consentString.cmpId,
-            cmpVersion: consentString.cmpVersion,
+            cmpId: CMPConstants.CMPInfos.ID,
+            cmpVersion: CMPConstants.CMPInfos.VERSION,
             consentScreen: consentString.consentScreen,
-            consentLanguage: consentString.consentLanguage,
+            consentLanguage: consentLanguage,
             vendorListVersion: consentString.vendorListVersion,
             maxVendorId: consentString.maxVendorId,
             allowedPurposes: updatedAllowedPurposes,
@@ -164,12 +168,14 @@ internal extension CMPConsentString {
      - Parameters:
         - purposeId: The purpose id which should be removed from the consent list.
         - consentString: The consent string which should be copied.
+        - consentLanguage: The language that the CMP asked for consent in.
         - lastUpdated: The date that will be used as last updated date (optional, it will use the current date by default).
      - Returns: A new consent string with a consent removed for a particular purpose.
      */
     static func consentStringByRemovingConsent(forPurposeId purposeId: Int,
-                                             consentString: CMPConsentString,
-                                             lastUpdated: Date = Date()) -> CMPConsentString {
+                                               consentString: CMPConsentString,
+                                               consentLanguage: CMPLanguage,
+                                               lastUpdated: Date = Date()) -> CMPConsentString {
         
         let updatedAllowedPurposes = consentString.allowedPurposes.filteredIndexSet(includeInteger: { $0 != purposeId })
         
@@ -177,10 +183,10 @@ internal extension CMPConsentString {
             versionConfig: CMPVersionConfig.LATEST,
             created: consentString.created,
             lastUpdated: lastUpdated,
-            cmpId: consentString.cmpId,
-            cmpVersion: consentString.cmpVersion,
+            cmpId: CMPConstants.CMPInfos.ID,
+            cmpVersion: CMPConstants.CMPInfos.VERSION,
             consentScreen: consentString.consentScreen,
-            consentLanguage: consentString.consentLanguage,
+            consentLanguage: consentLanguage,
             vendorListVersion: consentString.vendorListVersion,
             maxVendorId: consentString.maxVendorId,
             allowedPurposes: updatedAllowedPurposes,
@@ -196,11 +202,13 @@ internal extension CMPConsentString {
      - Parameters:
         - vendorId: The vendor id which should be added to the consent list.
         - consentString: The consent string which should be copied.
+        - consentLanguage: The language that the CMP asked for consent in.
         - lastUpdated: The date that will be used as last updated date (optional, it will use the current date by default).
      - Returns: A new consent string with a consent given for a particular vendor.
      */
     static func consentStringByAddingConsent(forVendorId vendorId: Int,
                                              consentString: CMPConsentString,
+                                             consentLanguage: CMPLanguage,
                                              lastUpdated: Date = Date()) -> CMPConsentString {
         
         let updatedAllowedVendors = !consentString.allowedVendors.contains(vendorId) ?
@@ -210,10 +218,10 @@ internal extension CMPConsentString {
             versionConfig: CMPVersionConfig.LATEST,
             created: consentString.created,
             lastUpdated: lastUpdated,
-            cmpId: consentString.cmpId,
-            cmpVersion: consentString.cmpVersion,
+            cmpId: CMPConstants.CMPInfos.ID,
+            cmpVersion: CMPConstants.CMPInfos.VERSION,
             consentScreen: consentString.consentScreen,
-            consentLanguage: consentString.consentLanguage,
+            consentLanguage: consentLanguage,
             vendorListVersion: consentString.vendorListVersion,
             maxVendorId: consentString.maxVendorId,
             allowedPurposes: consentString.allowedPurposes,
@@ -229,11 +237,13 @@ internal extension CMPConsentString {
      - Parameters:
         - vendorId: The vendor id which should be removed from the consent list.
         - consentString: The consent string which should be copied.
+        - consentLanguage: The language that the CMP asked for consent in.
         - lastUpdated: The date that will be used as last updated date (optional, it will use the current date by default).
      - Returns: A new consent string with a consent removed for a particular vendor.
      */
     static func consentStringByRemovingConsent(forVendorId vendorId: Int,
                                                consentString: CMPConsentString,
+                                               consentLanguage: CMPLanguage,
                                                lastUpdated: Date = Date()) -> CMPConsentString {
         
         let updatedAllowedVendors = consentString.allowedVendors.filteredIndexSet(includeInteger: { $0 != vendorId })
@@ -242,10 +252,10 @@ internal extension CMPConsentString {
             versionConfig: CMPVersionConfig.LATEST,
             created: consentString.created,
             lastUpdated: lastUpdated,
-            cmpId: consentString.cmpId,
-            cmpVersion: consentString.cmpVersion,
+            cmpId: CMPConstants.CMPInfos.ID,
+            cmpVersion: CMPConstants.CMPInfos.VERSION,
             consentScreen: consentString.consentScreen,
-            consentLanguage: consentString.consentLanguage,
+            consentLanguage: consentLanguage,
             vendorListVersion: consentString.vendorListVersion,
             maxVendorId: consentString.maxVendorId,
             allowedPurposes: consentString.allowedPurposes,

--- a/framework/SmartCMP/Manager/CMPConsentManager.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManager.swift
@@ -213,7 +213,8 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
                         // Generate the updated consent string
                         self.consentString = CMPConsentString.consentString(fromUpdatedVendorList: vendorList,
                                                                             previousVendorList: previousVendorList,
-                                                                            previousConsentString: storedConsentString)
+                                                                            previousConsentString: storedConsentString,
+                                                                            consentLanguage: self.language)
                         
                         DispatchQueue.main.async {
                             // Display consent tool

--- a/framework/SmartCMP/UI/CMPConsentToolManager.swift
+++ b/framework/SmartCMP/UI/CMPConsentToolManager.swift
@@ -269,7 +269,7 @@ internal class CMPConsentToolManager {
         }
         
         // Generate new consent string
-        self.generatedConsentString = CMPConsentString.consentStringByAddingConsent(forPurposeId: id, consentString: self.generatedConsentString, lastUpdated: Date())
+        self.generatedConsentString = CMPConsentString.consentStringByAddingConsent(forPurposeId: id, consentString: self.generatedConsentString, consentLanguage: language, lastUpdated: Date())
     }
     
     /**
@@ -283,7 +283,7 @@ internal class CMPConsentToolManager {
         }
         
         // Generate new consent string
-        self.generatedConsentString = CMPConsentString.consentStringByRemovingConsent(forPurposeId: id, consentString: self.generatedConsentString, lastUpdated: Date())
+        self.generatedConsentString = CMPConsentString.consentStringByRemovingConsent(forPurposeId: id, consentString: self.generatedConsentString, consentLanguage: language, lastUpdated: Date())
         
     }
     
@@ -298,7 +298,7 @@ internal class CMPConsentToolManager {
         }
 
         // Generate new consent string
-        self.generatedConsentString = CMPConsentString.consentStringByAddingConsent(forVendorId: id, consentString: self.generatedConsentString, lastUpdated: Date())
+        self.generatedConsentString = CMPConsentString.consentStringByAddingConsent(forVendorId: id, consentString: self.generatedConsentString, consentLanguage: language, lastUpdated: Date())
         
     }
     
@@ -313,7 +313,7 @@ internal class CMPConsentToolManager {
         }
         
         // Generate new consent string
-        self.generatedConsentString = CMPConsentString.consentStringByRemovingConsent(forVendorId: id, consentString: self.generatedConsentString, lastUpdated: Date())
+        self.generatedConsentString = CMPConsentString.consentStringByRemovingConsent(forVendorId: id, consentString: self.generatedConsentString, consentLanguage: language, lastUpdated: Date())
     }
     
     // MARK: - Utils

--- a/framework/SmartCMPTests/ConsentString/CMPConsentStringTests.swift
+++ b/framework/SmartCMPTests/ConsentString/CMPConsentStringTests.swift
@@ -473,10 +473,10 @@ class CMPConsentStringTests : XCTestCase {
         let expectedConsentString = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
                                                      created: date,
                                                      lastUpdated: updatedDate,
-                                                     cmpId: 1,
-                                                     cmpVersion: 2,
+                                                     cmpId: CMPConstants.CMPInfos.ID,
+                                                     cmpVersion: CMPConstants.CMPInfos.VERSION,
                                                      consentScreen: 3,
-                                                     consentLanguage: CMPLanguage(string: "en")!,
+                                                     consentLanguage: CMPLanguage(string: "fr")!,
                                                      allowedPurposes: [1, 2, 6, 7],
                                                      allowedVendors: [1, 2, 4, 40, 41, 42],
                                                      vendorList: updatedVendorList)
@@ -484,6 +484,7 @@ class CMPConsentStringTests : XCTestCase {
         let updatedConsentString = CMPConsentString.consentString(fromUpdatedVendorList: updatedVendorList,
                                                                   previousVendorList: vendorList,
                                                                   previousConsentString: consentString,
+                                                                  consentLanguage: CMPLanguage(string: "fr")!,
                                                                   lastUpdated: updatedDate)
         
         XCTAssertEqual(updatedConsentString, expectedConsentString)
@@ -508,10 +509,10 @@ class CMPConsentStringTests : XCTestCase {
         let expectedConsentString1 = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
                                                       created: date,
                                                       lastUpdated: updatedDate,
-                                                      cmpId: 1,
-                                                      cmpVersion: 2,
+                                                      cmpId: CMPConstants.CMPInfos.ID,
+                                                      cmpVersion: CMPConstants.CMPInfos.VERSION,
                                                       consentScreen: 3,
-                                                      consentLanguage: CMPLanguage(string: "en")!,
+                                                      consentLanguage: CMPLanguage(string: "fr")!,
                                                       vendorListVersion: 1,
                                                       maxVendorId: 6,
                                                       allowedPurposes: [1, 2, 4],
@@ -520,17 +521,17 @@ class CMPConsentStringTests : XCTestCase {
         let expectedConsentString2 = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
                                                       created: date,
                                                       lastUpdated: updatedDate,
-                                                      cmpId: 1,
-                                                      cmpVersion: 2,
+                                                      cmpId: CMPConstants.CMPInfos.ID,
+                                                      cmpVersion: CMPConstants.CMPInfos.VERSION,
                                                       consentScreen: 3,
-                                                      consentLanguage: CMPLanguage(string: "en")!,
+                                                      consentLanguage: CMPLanguage(string: "fr")!,
                                                       vendorListVersion: 1,
                                                       maxVendorId: 6,
                                                       allowedPurposes: [1, 2],
                                                       allowedVendors: [1, 2, 4])
         
-        let idDoesNotExistsConsentString = CMPConsentString.consentStringByAddingConsent(forPurposeId: 4, consentString: consentString, lastUpdated: updatedDate)
-        let idExistsConsentString = CMPConsentString.consentStringByAddingConsent(forPurposeId: 1, consentString: consentString, lastUpdated: updatedDate)
+        let idDoesNotExistsConsentString = CMPConsentString.consentStringByAddingConsent(forPurposeId: 4, consentString: consentString, consentLanguage: CMPLanguage(string: "fr")!, lastUpdated: updatedDate)
+        let idExistsConsentString = CMPConsentString.consentStringByAddingConsent(forPurposeId: 1, consentString: consentString, consentLanguage: CMPLanguage(string: "fr")!, lastUpdated: updatedDate)
         
         XCTAssertEqual(idDoesNotExistsConsentString, expectedConsentString1)
         XCTAssertEqual(idExistsConsentString, expectedConsentString2)
@@ -555,10 +556,10 @@ class CMPConsentStringTests : XCTestCase {
         let expectedConsentString1 = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
                                                       created: date,
                                                       lastUpdated: updatedDate,
-                                                      cmpId: 1,
-                                                      cmpVersion: 2,
+                                                      cmpId: CMPConstants.CMPInfos.ID,
+                                                      cmpVersion: CMPConstants.CMPInfos.VERSION,
                                                       consentScreen: 3,
-                                                      consentLanguage: CMPLanguage(string: "en")!,
+                                                      consentLanguage: CMPLanguage(string: "fr")!,
                                                       vendorListVersion: 1,
                                                       maxVendorId: 6,
                                                       allowedPurposes: [2],
@@ -567,17 +568,17 @@ class CMPConsentStringTests : XCTestCase {
         let expectedConsentString2 = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
                                                       created: date,
                                                       lastUpdated: updatedDate,
-                                                      cmpId: 1,
-                                                      cmpVersion: 2,
+                                                      cmpId: CMPConstants.CMPInfos.ID,
+                                                      cmpVersion: CMPConstants.CMPInfos.VERSION,
                                                       consentScreen: 3,
-                                                      consentLanguage: CMPLanguage(string: "en")!,
+                                                      consentLanguage: CMPLanguage(string: "fr")!,
                                                       vendorListVersion: 1,
                                                       maxVendorId: 6,
                                                       allowedPurposes: [1, 2],
                                                       allowedVendors: [1, 2, 4])
         
-        let idExistsConsentString = CMPConsentString.consentStringByRemovingConsent(forPurposeId: 1, consentString: consentString, lastUpdated: updatedDate)
-        let idDoesNotExistsConsentString = CMPConsentString.consentStringByRemovingConsent(forPurposeId: 4, consentString: consentString, lastUpdated: updatedDate)
+        let idExistsConsentString = CMPConsentString.consentStringByRemovingConsent(forPurposeId: 1, consentString: consentString, consentLanguage: CMPLanguage(string: "fr")!, lastUpdated: updatedDate)
+        let idDoesNotExistsConsentString = CMPConsentString.consentStringByRemovingConsent(forPurposeId: 4, consentString: consentString, consentLanguage: CMPLanguage(string: "fr")!, lastUpdated: updatedDate)
         
         XCTAssertEqual(idExistsConsentString, expectedConsentString1)
         XCTAssertEqual(idDoesNotExistsConsentString, expectedConsentString2)
@@ -602,10 +603,10 @@ class CMPConsentStringTests : XCTestCase {
         let expectedConsentString1 = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
                                                       created: date,
                                                       lastUpdated: updatedDate,
-                                                      cmpId: 1,
-                                                      cmpVersion: 2,
+                                                      cmpId: CMPConstants.CMPInfos.ID,
+                                                      cmpVersion: CMPConstants.CMPInfos.VERSION,
                                                       consentScreen: 3,
-                                                      consentLanguage: CMPLanguage(string: "en")!,
+                                                      consentLanguage: CMPLanguage(string: "fr")!,
                                                       vendorListVersion: 1,
                                                       maxVendorId: 6,
                                                       allowedPurposes: [1, 2],
@@ -614,17 +615,17 @@ class CMPConsentStringTests : XCTestCase {
         let expectedConsentString2 = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
                                                       created: date,
                                                       lastUpdated: updatedDate,
-                                                      cmpId: 1,
-                                                      cmpVersion: 2,
+                                                      cmpId: CMPConstants.CMPInfos.ID,
+                                                      cmpVersion: CMPConstants.CMPInfos.VERSION,
                                                       consentScreen: 3,
-                                                      consentLanguage: CMPLanguage(string: "en")!,
+                                                      consentLanguage: CMPLanguage(string: "fr")!,
                                                       vendorListVersion: 1,
                                                       maxVendorId: 6,
                                                       allowedPurposes: [1, 2],
                                                       allowedVendors: [1, 2, 4])
         
-        let idDoesNotExistsConsentString = CMPConsentString.consentStringByAddingConsent(forVendorId: 6, consentString: consentString, lastUpdated: updatedDate)
-        let idExistsConsentString = CMPConsentString.consentStringByAddingConsent(forVendorId: 1, consentString: consentString, lastUpdated: updatedDate)
+        let idDoesNotExistsConsentString = CMPConsentString.consentStringByAddingConsent(forVendorId: 6, consentString: consentString, consentLanguage: CMPLanguage(string: "fr")!, lastUpdated: updatedDate)
+        let idExistsConsentString = CMPConsentString.consentStringByAddingConsent(forVendorId: 1, consentString: consentString, consentLanguage: CMPLanguage(string: "fr")!, lastUpdated: updatedDate)
         
         XCTAssertEqual(idDoesNotExistsConsentString, expectedConsentString1)
         XCTAssertEqual(idExistsConsentString, expectedConsentString2)
@@ -649,10 +650,10 @@ class CMPConsentStringTests : XCTestCase {
         let expectedConsentString1 = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
                                                       created: date,
                                                       lastUpdated: updatedDate,
-                                                      cmpId: 1,
-                                                      cmpVersion: 2,
+                                                      cmpId: CMPConstants.CMPInfos.ID,
+                                                      cmpVersion: CMPConstants.CMPInfos.VERSION,
                                                       consentScreen: 3,
-                                                      consentLanguage: CMPLanguage(string: "en")!,
+                                                      consentLanguage: CMPLanguage(string: "fr")!,
                                                       vendorListVersion: 1,
                                                       maxVendorId: 6,
                                                       allowedPurposes: [1, 2],
@@ -661,17 +662,17 @@ class CMPConsentStringTests : XCTestCase {
         let expectedConsentString2 = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
                                                       created: date,
                                                       lastUpdated: updatedDate,
-                                                      cmpId: 1,
-                                                      cmpVersion: 2,
+                                                      cmpId: CMPConstants.CMPInfos.ID,
+                                                      cmpVersion: CMPConstants.CMPInfos.VERSION,
                                                       consentScreen: 3,
-                                                      consentLanguage: CMPLanguage(string: "en")!,
+                                                      consentLanguage: CMPLanguage(string: "fr")!,
                                                       vendorListVersion: 1,
                                                       maxVendorId: 6,
                                                       allowedPurposes: [1, 2],
                                                       allowedVendors: [2, 4])
         
-        let idDoesNotExistsConsentString = CMPConsentString.consentStringByRemovingConsent(forVendorId: 6, consentString: consentString, lastUpdated: updatedDate)
-        let idExistsConsentString = CMPConsentString.consentStringByRemovingConsent(forVendorId: 1, consentString: consentString, lastUpdated: updatedDate)
+        let idDoesNotExistsConsentString = CMPConsentString.consentStringByRemovingConsent(forVendorId: 6, consentString: consentString, consentLanguage: CMPLanguage(string: "fr")!, lastUpdated: updatedDate)
+        let idExistsConsentString = CMPConsentString.consentStringByRemovingConsent(forVendorId: 1, consentString: consentString, consentLanguage: CMPLanguage(string: "fr")!, lastUpdated: updatedDate)
         
         XCTAssertEqual(idDoesNotExistsConsentString, expectedConsentString1)
         XCTAssertEqual(idExistsConsentString, expectedConsentString2)


### PR DESCRIPTION
SmartCMP was using a placeholder CMP ID until now.
Since it has been registered at the IAB, we can now uses our official CMP ID: **33** (http://advertisingconsent.eu/iab-europe-transparency-consent-framework-list-of-registered-cmps/)

This pull request also documents the CMP ID reuse conditions applicable to forks. It also fixes an issue during consent string modification where old CMP ID was always kept (as well as old values for version & language).
