### PR TITLE
Several CMPConsentToolConfiguration improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,23 @@ Drag the ```SmartCMP.xcodeproj``` to your project and add the ```SmartCMP.framew
 You must setup the CMP before using it. Start by creating a configuration object that will define how the first screen of the consent tool will look like:
 
     let config = CMPConsentToolConfiguration(logo: UIImage(named: "logo")!,
-                                           homeScreenText: "[Place here your legal privacy notice for the consent tool, compliant with GDPR]",
-                                           homeScreenManageConsentButtonTitle: "MANAGE MY CHOICES",
-                                           homeScreenCloseButtonTitle: "GOT IT, THANKS!",
-                                           consentManagementScreenTitle: "Privacy preferences",
-                                           consentManagementCancelButtonTitle: "Cancel",
-                                           consentManagementSaveButtonTitle: "Save",
-                                           consentManagementScreenVendorsSectionHeaderText: "Vendors",
-                                           consentManagementScreenPurposeSectionHeaderText: "Purpose",
-                                           consentManagementVendorsControllerAccessText: "Authorized vendors",
-                                           consentManagementActivatedText: "yes",
-                                           consentManagementDeactivatedText: "no",
-                                           consentManagementPurposeDetailAllowText: "Allowed",
-                                           consentManagementVendorDetailViewPolicyText: "View privacy policy",
-                                           consentManagementVendorDetailPurposesText: "Required purposes",
-                                           consentManagementVendorDetailLegitimatePurposesText: "Legitimate interest purposes",
-                                           consentManagementVendorDetailFeaturesText: "Features")
+                                             homeScreenText: "[Place here your legal privacy notice for the consent tool, compliant with GDPR]",
+                                             homeScreenManageConsentButtonTitle: "MANAGE MY CHOICES",
+                                             homeScreenCloseButtonTitle: "GOT IT, THANKS!",
+                                             consentManagementScreenTitle: "Privacy preferences",
+                                             consentManagementCancelButtonTitle: "Cancel",
+                                             consentManagementSaveButtonTitle: "Save",
+                                             consentManagementScreenVendorsSectionHeaderText: "Vendors",
+                                             consentManagementScreenPurposesSectionHeaderText: "Purposes",
+                                             consentManagementVendorsControllerAccessText: "Authorized vendors",
+                                             consentManagementActivatedText: "yes",
+                                             consentManagementDeactivatedText: "no",
+                                             consentManagementPurposeDetailTitle: "Purpose",
+                                             consentManagementPurposeDetailAllowText: "Allowed",
+                                             consentManagementVendorDetailViewPolicyText: "View privacy policy",
+                                             consentManagementVendorDetailPurposesText: "Required purposes",
+                                             consentManagementVendorDetailLegitimatePurposesText: "Legitimate interest purposes",
+                                             consentManagementVendorDetailFeaturesText: "Features")
 
 Call the ```configure()``` method on ```CMPConsentManager.shared``` to start the CMP.
 

--- a/demo/SmartCMPDemo/AppDelegate.swift
+++ b/demo/SmartCMPDemo/AppDelegate.swift
@@ -68,17 +68,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CMPConsentManagerDelegate
                                            consentManagementCancelButtonTitle: "Cancel",
                                            consentManagementSaveButtonTitle: "Save",
                                            consentManagementScreenVendorsSectionHeaderText: "Vendors",
-                                           consentManagementScreenPurposeSectionHeaderText: "Purpose",
+                                           consentManagementScreenPurposesSectionHeaderText: "Purposes",
                                            consentManagementVendorsControllerAccessText: "Authorized vendors",
                                            consentManagementActivatedText: "yes",
                                            consentManagementDeactivatedText: "no",
+                                           consentManagementPurposeDetailTitle: "Purpose",
                                            consentManagementPurposeDetailAllowText: "Allowed",
                                            consentManagementVendorDetailViewPolicyText: "View privacy policy",
                                            consentManagementVendorDetailPurposesText: "Required purposes",
                                            consentManagementVendorDetailLegitimatePurposesText: "Legitimate interest purposes",
                                            consentManagementVendorDetailFeaturesText: "Features")
-        
-
     }
     
 }

--- a/framework/SmartCMP/UI/CMPConsentToolConfiguration.swift
+++ b/framework/SmartCMP/UI/CMPConsentToolConfiguration.swift
@@ -61,10 +61,10 @@ public class CMPConsentToolConfiguration : NSObject {
     /// Eg: "Vendors"
     let consentManagementScreenVendorsSectionHeaderText: String
     
-    /// Text of the purpose section header.
+    /// Text of the purposes section header.
     ///
-    /// Eg: "Purpose"
-    let consentManagementScreenPurposeSectionHeaderText: String
+    /// Eg: "Purposes"
+    let consentManagementScreenPurposesSectionHeaderText: String
     
     /// Text to access the full vendor list.
     ///
@@ -81,9 +81,14 @@ public class CMPConsentToolConfiguration : NSObject {
     /// Eg: "no"
     let consentManagementDeactivatedText: String
     
+    /// The title of the purpose detail screen.
+    ///
+    /// Eg: "Purpose"
+    let consentManagementPurposeDetailTitle: String
+    
     // MARK: - Purpose Detail Controller
     
-    /// Text displayed next to the switch to allow / disallow a purpose or a vendor.
+    /// Text displayed next to the switch to allow / disallow a purpose.
     ///
     /// Eg: "Allowed"
     let consentManagementPurposeDetailAllowText: String
@@ -129,12 +134,12 @@ public class CMPConsentToolConfiguration : NSObject {
         - consentManagementVendorsControllerAccessText: The text displayed to access the whole vendor list.
         - consentManagementActivatedText: The text to displayed when a purpose / vendor has consent.
         - consentManagementDeactivatedText: The text to displayed when a purpose / vendor has no consent.
-        - consentManagementPurposeDetailAllowText: Text displayed next to the switch to allow / disallow a purpose or a vendor.
+        - consentManagementPurposeDetailTitle: The title of the purpose detail screen.
+        - consentManagementPurposeDetailAllowText: Text displayed next to the switch to allow / disallow a purpose.
         - consentManagementVendorDetailViewPolicyText: Text displayed to access vendor's privacy policy webpage.
         - consentManagementVendorDetailPurposesText: Text displayed as the title of the list of the vendor's purposes.
         - consentManagementVendorDetailLegitimatePurposesText: Text displayed as the title of the list of the vendor's legitimate purposes.
         - consentManagementVendorDetailFeaturesText: Text displayed as the title of the list of the vendor's features.
-     
      - Returns: A new instance of CMPConsentToolConfiguration.
      */
     @objc
@@ -146,10 +151,11 @@ public class CMPConsentToolConfiguration : NSObject {
                 consentManagementCancelButtonTitle: String,
                 consentManagementSaveButtonTitle: String,
                 consentManagementScreenVendorsSectionHeaderText: String,
-                consentManagementScreenPurposeSectionHeaderText: String,
+                consentManagementScreenPurposesSectionHeaderText: String,
                 consentManagementVendorsControllerAccessText: String,
                 consentManagementActivatedText: String,
                 consentManagementDeactivatedText: String,
+                consentManagementPurposeDetailTitle: String,
                 consentManagementPurposeDetailAllowText: String,
                 consentManagementVendorDetailViewPolicyText: String,
                 consentManagementVendorDetailPurposesText: String,
@@ -164,10 +170,11 @@ public class CMPConsentToolConfiguration : NSObject {
         self.consentManagementCancelButtonTitle = consentManagementCancelButtonTitle
         self.consentManagementSaveButtonTitle = consentManagementSaveButtonTitle
         self.consentManagementScreenVendorsSectionHeaderText = consentManagementScreenVendorsSectionHeaderText
-        self.consentManagementScreenPurposeSectionHeaderText = consentManagementScreenPurposeSectionHeaderText
+        self.consentManagementScreenPurposesSectionHeaderText = consentManagementScreenPurposesSectionHeaderText
         self.consentManagementVendorsControllerAccessText = consentManagementVendorsControllerAccessText
         self.consentManagementActivatedText = consentManagementActivatedText
         self.consentManagementDeactivatedText = consentManagementDeactivatedText
+        self.consentManagementPurposeDetailTitle = consentManagementPurposeDetailTitle
         self.consentManagementPurposeDetailAllowText = consentManagementPurposeDetailAllowText
         self.consentManagementVendorDetailViewPolicyText = consentManagementVendorDetailViewPolicyText
         self.consentManagementVendorDetailPurposesText = consentManagementVendorDetailPurposesText

--- a/framework/SmartCMP/UI/CMPConsentToolPreferencesViewController.swift
+++ b/framework/SmartCMP/UI/CMPConsentToolPreferencesViewController.swift
@@ -125,7 +125,7 @@ internal class CMPConsentToolPreferencesViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         switch section {
         case CMPConsentToolPreferencesViewController.PurposeSection:
-            return consentToolManager?.configuration.consentManagementScreenPurposeSectionHeaderText
+            return consentToolManager?.configuration.consentManagementScreenPurposesSectionHeaderText
         default:
             return consentToolManager?.configuration.consentManagementScreenVendorsSectionHeaderText
         }

--- a/framework/SmartCMP/UI/CMPConsentToolPurposeViewController.swift
+++ b/framework/SmartCMP/UI/CMPConsentToolPurposeViewController.swift
@@ -36,7 +36,7 @@ internal class CMPConsentToolPurposeViewController: UITableViewController {
         super.viewDidLoad()
 
         // Configure texts
-        self.title = consentToolManager?.configuration.consentManagementScreenPurposeSectionHeaderText
+        self.title = consentToolManager?.configuration.consentManagementPurposeDetailTitle
         
         self.purposeNameLabel.text = purpose?.name
         self.purposeDescriptionLabel.text = purpose?.purposeDescription


### PR DESCRIPTION
This pull request contains several improvements for the class CMPConsentToolConfiguration.

The biggest one is a new label to configure the title of the purpose details screen (in the previous version, this title was always using the same label as the purposes section of the preferences screen).
The PR also contains some minors comments & README changes.