### PR TITLE
Added a boolean to check if the consent tool has been opened successfully

### DIFF
--- a/demo/SmartCMPDemo/AppDelegate.swift
+++ b/demo/SmartCMPDemo/AppDelegate.swift
@@ -47,7 +47,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CMPConsentManagerDelegate
         
         // You should display the consent tool UI, when user is ready…
         if let controller = self.window?.rootViewController {
-            consentManager.showConsentTool(fromController: controller)
+            let _ = consentManager.showConsentTool(fromController: controller)
         }
         
         // Since the vendor list is provided in parameter of this delegate method, you can also build your own UI to ask for

--- a/demo/SmartCMPDemo/ViewController.swift
+++ b/demo/SmartCMPDemo/ViewController.swift
@@ -59,7 +59,19 @@ class ViewController: UIViewController {
     // MARK: Show consent tool action
     
     @IBAction func showConsentToolButtonTapped(_ sender: Any) {
-        CMPConsentManager.shared.showConsentTool(fromController: self)
+        // Showing the consent tool manually
+        if !CMPConsentManager.shared.showConsentTool(fromController: self) {
+            
+            // Note: showing the consent tool might fail for several reasons (check the API documentation for more information).
+            // For better user experience, it is advised to display an error if the consent tool can't be opened when it has been
+            // requested by the user.
+            let alert = UIAlertController(title: "Service unavailable",
+                                          message: "Setting your privacy preferences is not possible at the moment, please try again later",
+                                          preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self.present(alert, animated: true)
+            
+        }
     }
     
 }

--- a/framework/SmartCMP/Manager/CMPConsentManager.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManager.swift
@@ -160,24 +160,31 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
     /**
      Present the consent tool UI modally.
      
+     Note: the consent tool will not be displayed if
+     
+     - you haven't called the configure() method first
+     - the consent tool is already displayed
+     - the vendor list has not been retrieved yet (or can't be retrieved for the moment).
+     
      - Parameter controller: The UIViewController instance which should present the consent tool UI.
+     - Returns: true if the consent tool has been displayed properly, false if it can't be displayed.
      */
     @objc
-    public func showConsentTool(fromController controller: UIViewController) {
+    public func showConsentTool(fromController controller: UIViewController) -> Bool {
         // Log error and stop if configuration is not made
         guard self.configured else {
             logErrorMessage("CMPConsentManager is not configured for this session. Please call CMPConsentManager.shared.configure() first.")
-            return;
+            return false;
         }
         
         guard !self.consentToolIsShown else {
             logErrorMessage("CMPConsentManager is already showing the consent tool view controller.")
-            return;
+            return false;
         }
         
         guard let lastVendorList = self.lastVendorList else {
             logErrorMessage("CMPConsentManager cannot show consent tool as no vendor list is available. Please wait.")
-            return;
+            return false;
         }
         
         // Consider consent tool as shown
@@ -188,6 +195,7 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
         self.consentToolManager = manager
         manager.showConsentTool(fromController: controller)
         
+        return true
     }
     
     // MARK: - CMPVendorListManagerDelegate
@@ -264,7 +272,7 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
             } else {
                 // There is no delegate so the CMP will ask for user's consent automatically
                 if let viewController = UIApplication.shared.keyWindow?.rootViewController {
-                    showConsentTool(fromController: viewController)
+                    let _ = showConsentTool(fromController: viewController)
                 }
             }
         } else {


### PR DESCRIPTION
Opening the consent tool might fail for several reasons.
It is not an issue when the opening is triggered automatically, but it can be bad for UX if the opening has been triggered by the user.

To prevent that, this PR adds a boolean returned by the method showConsentTool() to check if the opening is successful. If not, an error alert can be displayed by the app (demo app updated).