### PR TITLE
The style of preferences view controllers is not inherited from the app anymore

### DIFF
--- a/framework/SmartCMP.xcodeproj/project.pbxproj
+++ b/framework/SmartCMP.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		7E800B652090BB28001FC83B /* CMPURLDefaultSessionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E800B642090BB28001FC83B /* CMPURLDefaultSessionProvider.swift */; };
 		7E800B672090BF7A001FC83B /* CMPURLSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E800B662090BF7A001FC83B /* CMPURLSessionTests.swift */; };
 		7EBB616620932BFF00EAD3C7 /* vendors_updated.json in Resources */ = {isa = PBXBuildFile; fileRef = 7EBB616520932BFF00EAD3C7 /* vendors_updated.json */; };
+		7EE68E2220B56626007394CE /* CMPConsentToolBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE68E2120B56626007394CE /* CMPConsentToolBaseViewController.swift */; };
 		8504B78820921E020011BE81 /* CMPPreferenceTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8504B78520921E020011BE81 /* CMPPreferenceTableViewCell.swift */; };
 		8504B78B209237070011BE81 /* CMPVendorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8504B78A209237070011BE81 /* CMPVendorTableViewCell.swift */; };
 		8529CA45209717DE00759E68 /* CMPConsentToolVendorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8529CA44209717DE00759E68 /* CMPConsentToolVendorViewController.swift */; };
@@ -116,6 +117,7 @@
 		7E800B642090BB28001FC83B /* CMPURLDefaultSessionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPURLDefaultSessionProvider.swift; sourceTree = "<group>"; };
 		7E800B662090BF7A001FC83B /* CMPURLSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPURLSessionTests.swift; sourceTree = "<group>"; };
 		7EBB616520932BFF00EAD3C7 /* vendors_updated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = vendors_updated.json; sourceTree = "<group>"; };
+		7EE68E2120B56626007394CE /* CMPConsentToolBaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPConsentToolBaseViewController.swift; sourceTree = "<group>"; };
 		8504B78520921E020011BE81 /* CMPPreferenceTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CMPPreferenceTableViewCell.swift; sourceTree = "<group>"; };
 		8504B78A209237070011BE81 /* CMPVendorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPVendorTableViewCell.swift; sourceTree = "<group>"; };
 		8529CA44209717DE00759E68 /* CMPConsentToolVendorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPConsentToolVendorViewController.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 				E966611A2092174F00FCA161 /* CMPConsentToolManagerDelegate.swift */,
 				E966611C2093222200FCA161 /* CMPConsentToolConfiguration.swift */,
 				E9644105208F8420007FD26A /* CMPConsentToolViewController.swift */,
+				7EE68E2120B56626007394CE /* CMPConsentToolBaseViewController.swift */,
 				E934FBD7209084E500FE808C /* CMPConsentToolPreferencesViewController.swift */,
 				E934FBDB2090850E00FE808C /* CMPConsentToolPurposeViewController.swift */,
 				E934FBD9209084F400FE808C /* CMPConsentToolVendorsViewController.swift */,
@@ -502,6 +505,7 @@
 				7E800B522090AEAC001FC83B /* CMPVendorList.swift in Sources */,
 				7E800B532090AEAC001FC83B /* CMPPurpose.swift in Sources */,
 				7E25FC70208F51AB00D05789 /* CMPVersionConfig.swift in Sources */,
+				7EE68E2220B56626007394CE /* CMPConsentToolBaseViewController.swift in Sources */,
 				7E800B542090AEAC001FC83B /* CMPFeature.swift in Sources */,
 				E966611B2092174F00FCA161 /* CMPConsentToolManagerDelegate.swift in Sources */,
 				E934FBDC2090850E00FE808C /* CMPConsentToolPurposeViewController.swift in Sources */,

--- a/framework/SmartCMP/UI/CMPConsentToolBaseViewController.swift
+++ b/framework/SmartCMP/UI/CMPConsentToolBaseViewController.swift
@@ -1,0 +1,50 @@
+//
+//  CMPConsentToolBaseViewController.swift
+//  SmartCMP
+//
+//  Created by Loïc GIRON DIT METAZ on 23/05/2018.
+//  Copyright © 2018 Smart AdServer.
+//
+//  This software is distributed under the Creative Commons Legal Code, Attribution 3.0 Unported license.
+//  Check the LICENSE file for more information.
+//
+
+import Foundation
+
+/**
+ Base consent tool view controller used for the global configuration of all preferences view controllers.
+ */
+internal class CMPConsentToolBaseViewController: UITableViewController {
+    
+    /// Bar style.
+    let barStyle = UIBarStyle.default
+    
+    /// Status bar style.
+    let statusBarStyle = UIStatusBarStyle.default
+    
+    /// Navigation bar color.
+    let navigationBarTintColor = UIColor(red: 247.0/255.0, green: 247.0/255.0, blue: 247.0/255.0, alpha: 1.0)
+    
+    /// Title label color.
+    let titleTintColor = UIColor.black
+    
+    /// Navigation bar button color.
+    let navigationButtonTintColor = UIColor(red: 14.0/255, green: 122.0/255, blue: 254.0/255, alpha: 1.0)
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // Setting the navigation bar to 'default' colors
+        navigationController?.navigationBar.barStyle = barStyle
+        navigationController?.navigationBar.barTintColor = navigationBarTintColor
+        navigationController?.navigationBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor: titleTintColor]
+        navigationController?.navigationBar.tintColor = navigationButtonTintColor
+        
+        setNeedsStatusBarAppearanceUpdate()
+    }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return statusBarStyle
+    }
+    
+}

--- a/framework/SmartCMP/UI/CMPConsentToolPreferencesViewController.swift
+++ b/framework/SmartCMP/UI/CMPConsentToolPreferencesViewController.swift
@@ -14,7 +14,7 @@ import UIKit
 /**
  Consent tool preferences view controller.
  */
-internal class CMPConsentToolPreferencesViewController: UITableViewController {
+internal class CMPConsentToolPreferencesViewController: CMPConsentToolBaseViewController {
     
     // MARK: - UI Elements
     
@@ -37,16 +37,13 @@ internal class CMPConsentToolPreferencesViewController: UITableViewController {
         
         self.title = consentToolManager?.configuration.consentManagementScreenTitle
         
-        let color = UINavigationBar.appearance().tintColor ?? UIColor(red: 14.0/255, green: 122.0/255, blue: 254.0/255, alpha: 1.0)
-        let activeColor = UINavigationBar.appearance().tintColor ?? UIColor(red: 14.0/255, green: 122.0/255, blue: 254.0/255, alpha: 0.7)
-        
         // Cancel button
         let btnBack = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 20))
         btnBack.setTitle(consentToolManager?.configuration.consentManagementCancelButtonTitle, for: .normal)
         btnBack.titleLabel?.textAlignment = .left
         btnBack.addTarget(self, action: #selector(cancelButtonTapped(sender:)), for: .touchUpInside)
-        btnBack.setTitleColor(color, for: .normal)
-        btnBack.setTitleColor(activeColor, for: .highlighted)
+        btnBack.setTitleColor(navigationButtonTintColor, for: .normal)
+        btnBack.setTitleColor(navigationButtonTintColor, for: .highlighted)
         let leftBarButton = UIBarButtonItem()
         leftBarButton.customView = btnBack
         self.navigationItem.leftBarButtonItem = leftBarButton
@@ -56,8 +53,8 @@ internal class CMPConsentToolPreferencesViewController: UITableViewController {
         btnSave.setTitle(consentToolManager?.configuration.consentManagementSaveButtonTitle, for: .normal)
         btnSave.titleLabel?.textAlignment = .right
         btnSave.addTarget(self, action: #selector(saveButtonTapped(sender:)), for: .touchUpInside)
-        btnSave.setTitleColor(color, for: .normal)
-        btnSave.setTitleColor(activeColor, for: .highlighted)
+        btnSave.setTitleColor(navigationButtonTintColor, for: .normal)
+        btnSave.setTitleColor(navigationButtonTintColor, for: .highlighted)
         let rightBarButton = UIBarButtonItem()
         rightBarButton.customView = btnSave
         self.navigationItem.rightBarButtonItem = rightBarButton
@@ -65,6 +62,8 @@ internal class CMPConsentToolPreferencesViewController: UITableViewController {
         // Footer
         self.tableView.tableFooterView = UIView()
         self.view.backgroundColor = UIColor.groupTableViewBackground
+        
+        setNeedsStatusBarAppearanceUpdate()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/framework/SmartCMP/UI/CMPConsentToolPurposeViewController.swift
+++ b/framework/SmartCMP/UI/CMPConsentToolPurposeViewController.swift
@@ -14,7 +14,7 @@ import UIKit
 /**
  Consent tool purposes view controller.
  */
-internal class CMPConsentToolPurposeViewController: UITableViewController {
+internal class CMPConsentToolPurposeViewController: CMPConsentToolBaseViewController {
     
     /// The purpose displayed by the view controller
     weak var purpose: CMPPurpose?

--- a/framework/SmartCMP/UI/CMPConsentToolVendorViewController.swift
+++ b/framework/SmartCMP/UI/CMPConsentToolVendorViewController.swift
@@ -15,7 +15,7 @@ import SafariServices
 /**
  Consent tool vendors view controller.
  */
-internal class CMPConsentToolVendorViewController: UITableViewController {
+internal class CMPConsentToolVendorViewController: CMPConsentToolBaseViewController {
 
     /// The vendor displayed by the view controller
     var vendor: CMPVendor?

--- a/framework/SmartCMP/UI/CMPConsentToolVendorsViewController.swift
+++ b/framework/SmartCMP/UI/CMPConsentToolVendorsViewController.swift
@@ -14,7 +14,7 @@ import UIKit
 /**
  Consent tool vendors view controller.
  */
-internal class CMPConsentToolVendorsViewController: UITableViewController {
+internal class CMPConsentToolVendorsViewController: CMPConsentToolBaseViewController {
     
     // MARK: - UI Elements
 


### PR DESCRIPTION
In the current CMP, preferences view controllers inherits from the app theme.
In some apps, it can leads to invisible navigation buttons and other visual glitches.

This PR remove the automatic style for preferences view controllers until a better solution is found.