### PR TITLE
Added an 'AdvertisingConsentStatus' key to handle third party SDK using binary consent for the advertising purpose

### DIFF
--- a/framework/SmartCMP/CMPConstants.swift
+++ b/framework/SmartCMP/CMPConstants.swift
@@ -12,29 +12,44 @@
 import Foundation
 
 /**
- General constants for SmartCMP
+ General constants for SmartCMP.
  */
 internal struct CMPConstants {
     
-    /// Generic information on the CMP framework
+    /// Generic information on the CMP framework.
     struct CMPInfos {
-        static let VERSION = 1
-        static let ID = 33  // '33' IS THE OFFICIAL CMP ID FOR SmartCMP.
-                            // You can use this ID as long as you don't change the source code of this project.
-                            // If you don't use it exactly as distributed in the official Smart AdServer repository,
-                            // you must get your own CMP ID by registering here: https://register.consensu.org/CMP
+        static let VERSION                          = 1
+        
+        // WARNING: '33' IS THE OFFICIAL CMP ID FOR SmartCMP.
+        // You can use this ID as long as you don't change the source code of this project.
+        // If you don't use it exactly as distributed in the official Smart AdServer repository,
+        // you must get your own CMP ID by registering here: https://register.consensu.org/CMP
+        static let ID                               = 33
     }
     
-    /// IAB Keys for NSUserDefault storage
+    /// IAB Keys for NSUserDefaults storage.
     struct IABConsentKeys {
         static let CMPPresent                       = "IABConsent_CMPPresent"
         static let SubjectToGDPR                    = "IABConsent_SubjectToGDPR"
         static let ConsentString                    = "IABConsent_ConsentString"
         static let ParsedPurposeConsent             = "IABConsent_ParsedPurposeConsent"
-        static let ParsedVendorConsent              = "IABConsent_ParsedVendorConsent"        
+        static let ParsedVendorConsent              = "IABConsent_ParsedVendorConsent"
+    }
+    
+    /// The AdvertisingConsentStatus NSUserDefaults key contains the current user consent for the advertising
+    /// purpose of the current vendor list.
+    ///
+    /// This status is only based on the answer of the user on the advertising purpose and does not take
+    /// vendors status into account. It should only be used for third party advertisement SDK that are not
+    /// IAB compliant.
+    ///
+    /// Note: this key is not part of the IAB specification.
+    struct AdvertisingConsentStatus {
+        static let PurposeId                        = 3 
+        static let Key                              = "SmartCMP_advertisingConsentStatus"
     }
  
-    /// Vendor list configuration
+    /// Vendor list configuration.
     struct VendorList {
         static let DefaultEndPoint                  = "https://vendorlist.consensu.org/vendorlist.json"
         static let VersionedEndPoint                = "https://vendorlist.consensu.org/v-{version}/vendorlist.json"

--- a/framework/SmartCMP/ConsentString/CMPConsentString.swift
+++ b/framework/SmartCMP/ConsentString/CMPConsentString.swift
@@ -14,7 +14,7 @@ import Foundation
 /**
  Representation of an IAB consent string.
  */
-@objc public class CMPConsentString : NSObject, NSCopying {
+@objc public class CMPConsentString: NSObject, NSCopying {
     
     /// The type of encoding of the consent string.
     internal enum ConsentEncoding {

--- a/framework/SmartCMP/Manager/CMPConsentManager.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManager.swift
@@ -295,13 +295,14 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
      Method called when the consent string has changed.
      */
     private func consentStringChanged() {
-        guard let newConsentString = self.consentString else {
+        guard let newConsentString = consentString else {
             return;
         }
         
-        self.saveConsentString(newConsentString.consentString)
-        self.saveVendorConsentString(newConsentString.parsedVendorConsents)
-        self.savePurposeConsentString(newConsentString.parsedPurposeConsents)
+        saveConsentString(newConsentString.consentString)
+        saveVendorConsentString(newConsentString.parsedVendorConsents)
+        savePurposeConsentString(newConsentString.parsedPurposeConsents)
+        saveAdvertisingConsentStatus(forConsentString: newConsentString)
     }
         
     // MARK: - Utils - Error Display
@@ -368,6 +369,16 @@ public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPCons
      */
     internal func savePurposeConsentString(_ string: String) {
         saveStringToUserDefaults(string: string, key: CMPConstants.IABConsentKeys.ParsedPurposeConsent)
+    }
+    
+    /**
+     Save the advertising consent status in user defaults.
+     
+     - Parameters consentString: The consent string from which the advertising consent status will be retrieved.
+     */
+    internal func saveAdvertisingConsentStatus(forConsentString consentString: CMPConsentString) {
+        let advertisingConsentStatusString = consentString.allowedPurposes.contains(CMPConstants.AdvertisingConsentStatus.PurposeId) ? "1" : "0"
+        saveStringToUserDefaults(string: advertisingConsentStatusString, key: CMPConstants.AdvertisingConsentStatus.Key)
     }
     
     /**

--- a/framework/SmartCMP/Manager/CMPConsentManager.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManager.swift
@@ -16,7 +16,7 @@ import AdSupport
  A class to manage the CMP.
  */
 @objc
-public class CMPConsentManager : NSObject, CMPVendorListManagerDelegate, CMPConsentToolManagerDelegate {
+public class CMPConsentManager: NSObject, CMPVendorListManagerDelegate, CMPConsentToolManagerDelegate {
 
     // MARK: - Global singleton
     

--- a/framework/SmartCMP/Manager/CMPConsentManagerDelegate.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManagerDelegate.swift
@@ -15,7 +15,7 @@ import Foundation
  Delegate of CMPConsentManager.
  */
 @objc
-public protocol CMPConsentManagerDelegate : class {
+public protocol CMPConsentManagerDelegate: class {
     
     /**
      Called when the consent manager found a reason to display the Consent Tool UI. The publisher should display

--- a/framework/SmartCMP/Model/CMPLanguage.swift
+++ b/framework/SmartCMP/Model/CMPLanguage.swift
@@ -15,7 +15,7 @@ import Foundation
  ISO 639-1 language representation for the CMPConsentString
  */
 @objc
-public class CMPLanguage : NSObject {
+public class CMPLanguage: NSObject {
     
     /// The CMP default language ('en' / English).
     @objc

--- a/framework/SmartCMP/Model/CMPVersionConfig.swift
+++ b/framework/SmartCMP/Model/CMPVersionConfig.swift
@@ -15,7 +15,7 @@ import Foundation
  Configuration for a given version of the consent string.
  */
 @objc
-public class CMPVersionConfig : NSObject {
+public class CMPVersionConfig: NSObject {
     
     /// The lastest version of the consent string.
     @objc

--- a/framework/SmartCMP/Network/CMPURLDefaultSessionProvider.swift
+++ b/framework/SmartCMP/Network/CMPURLDefaultSessionProvider.swift
@@ -14,7 +14,7 @@ import Foundation
 /**
  Default implementation of CMPURLSessionProvider, used by the shared instance of CMPURLSession.
  */
-internal class CMPURLDefaultSessionProvider : CMPURLSessionProvider {
+internal class CMPURLDefaultSessionProvider: CMPURLSessionProvider {
     
     /// A shared instance of CMPURLDefaultSessionProvider (using the shared instance of URLSession).
     static let shared = CMPURLDefaultSessionProvider(session: URLSession.shared)

--- a/framework/SmartCMP/UI/CMPConsentToolConfiguration.swift
+++ b/framework/SmartCMP/UI/CMPConsentToolConfiguration.swift
@@ -15,7 +15,7 @@ import Foundation
  The configuration class of CMPConsentToolManager.
  */
 @objc
-public class CMPConsentToolConfiguration : NSObject {
+public class CMPConsentToolConfiguration: NSObject {
     
     // MARK: - Home Screen Fields
     

--- a/framework/SmartCMP/VendorList/CMPFeature.swift
+++ b/framework/SmartCMP/VendorList/CMPFeature.swift
@@ -15,7 +15,7 @@ import Foundation
  Representation of a feature.
  */
 @objc
-public class CMPFeature : NSObject, Codable {
+public class CMPFeature: NSObject, Codable {
     
     /// The id of the feature.
     @objc

--- a/framework/SmartCMP/VendorList/CMPPurpose.swift
+++ b/framework/SmartCMP/VendorList/CMPPurpose.swift
@@ -15,7 +15,7 @@ import Foundation
  Representation of a purpose.
  */
 @objc
-public class CMPPurpose : NSObject, Codable {
+public class CMPPurpose: NSObject, Codable {
     
     /// The id of the purpose.
     @objc

--- a/framework/SmartCMP/VendorList/CMPVendor.swift
+++ b/framework/SmartCMP/VendorList/CMPVendor.swift
@@ -15,7 +15,7 @@ import Foundation
  Representation of a vendor.
  */
 @objc
-public class CMPVendor : NSObject, Codable {
+public class CMPVendor: NSObject, Codable {
     
     /// The id of the vendor.
     @objc

--- a/framework/SmartCMP/VendorList/CMPVendorList.swift
+++ b/framework/SmartCMP/VendorList/CMPVendorList.swift
@@ -15,7 +15,7 @@ import Foundation
  Representation of a vendor list.
  */
 @objc
-public class CMPVendorList : NSObject, Codable {
+public class CMPVendorList: NSObject, Codable {
     
     /// The vendor list version.
     @objc

--- a/framework/SmartCMPTests/ConsentString/CMPConsentStringTests.swift
+++ b/framework/SmartCMPTests/ConsentString/CMPConsentStringTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 @testable import SmartCMP
 
-class CMPConsentStringTests : XCTestCase {
+class CMPConsentStringTests: XCTestCase {
     
     private func date(from string: String) -> Date {
         let formatter = DateFormatter()

--- a/framework/SmartCMPTests/Manager/CMPConsentManagerTests.swift
+++ b/framework/SmartCMPTests/Manager/CMPConsentManagerTests.swift
@@ -32,7 +32,7 @@ class CMPConsentManagerTests : XCTestCase {
     
     private func cleanUserDefaults() {
         let defaults = UserDefaults.standard
-        for key in [CMPConstants.IABConsentKeys.ConsentString, CMPConstants.IABConsentKeys.ParsedPurposeConsent, CMPConstants.IABConsentKeys.ParsedVendorConsent, CMPConstants.IABConsentKeys.SubjectToGDPR] {
+        for key in [CMPConstants.IABConsentKeys.ConsentString, CMPConstants.IABConsentKeys.ParsedPurposeConsent, CMPConstants.IABConsentKeys.ParsedVendorConsent, CMPConstants.IABConsentKeys.SubjectToGDPR, CMPConstants.AdvertisingConsentStatus.Key] {
             defaults.removeObject(forKey: key)
         }
         defaults.synchronize()
@@ -92,6 +92,48 @@ class CMPConsentManagerTests : XCTestCase {
         // Read string from NSUserDefaults
         let readValue = readUserDefaults(key: CMPConstants.IABConsentKeys.ParsedVendorConsent)
         XCTAssertEqual(newValue, readValue)
+    }
+    
+    func testSaveAdvertisingConsentStatus() {
+        // First value is nil
+        let initialValue = readUserDefaults(key: CMPConstants.AdvertisingConsentStatus.Key)
+        XCTAssertNil(initialValue)
+        
+        // Save a string to NSUserDefaults
+        let consentString1 = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
+                                              created: Date(timeIntervalSince1970: 2),
+                                              lastUpdated: Date(timeIntervalSince1970: 3),
+                                              cmpId: 4,
+                                              cmpVersion: 5,
+                                              consentScreen: 6,
+                                              consentLanguage: CMPLanguage(string: "en")!,
+                                              vendorListVersion: 8,
+                                              maxVendorId: 9,
+                                              allowedPurposes: [1],
+                                              allowedVendors: [])
+        CMPConsentManager.shared.saveAdvertisingConsentStatus(forConsentString: consentString1)
+        
+        // Read string from NSUserDefaults
+        let readValue1 = readUserDefaults(key: CMPConstants.AdvertisingConsentStatus.Key)
+        XCTAssertEqual("0", readValue1)
+        
+        // Save a string to NSUserDefaults
+        let consentString2 = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
+                                              created: Date(timeIntervalSince1970: 2),
+                                              lastUpdated: Date(timeIntervalSince1970: 3),
+                                              cmpId: 4,
+                                              cmpVersion: 5,
+                                              consentScreen: 6,
+                                              consentLanguage: CMPLanguage(string: "en")!,
+                                              vendorListVersion: 8,
+                                              maxVendorId: 9,
+                                              allowedPurposes: [1, 3],
+                                              allowedVendors: [])
+        CMPConsentManager.shared.saveAdvertisingConsentStatus(forConsentString: consentString2)
+        
+        // Read string from NSUserDefaults
+        let readValue2 = readUserDefaults(key: CMPConstants.AdvertisingConsentStatus.Key)
+        XCTAssertEqual("1", readValue2)
     }
     
 }

--- a/framework/SmartCMPTests/Manager/CMPConsentManagerTests.swift
+++ b/framework/SmartCMPTests/Manager/CMPConsentManagerTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 @testable import SmartCMP
 
-class CMPConsentManagerTests : XCTestCase {
+class CMPConsentManagerTests: XCTestCase {
     
     override func setUp() {
         super.setUp()

--- a/framework/SmartCMPTests/Model/CMPLanguageTests.swift
+++ b/framework/SmartCMPTests/Model/CMPLanguageTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 @testable import SmartCMP
 
-class CMPLanguageTests : XCTestCase {
+class CMPLanguageTests: XCTestCase {
     
     func testLanguageCanBeCreated() {
         let language1 = CMPLanguage(string: "en")

--- a/framework/SmartCMPTests/Network/CMPURLSessionTests.swift
+++ b/framework/SmartCMPTests/Network/CMPURLSessionTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 @testable import SmartCMP
 
-class CMPURLSessionTests : XCTestCase {
+class CMPURLSessionTests: XCTestCase {
     
     class MockError: Error {
         

--- a/framework/SmartCMPTests/Utils/CMPBitUtilsTest.swift
+++ b/framework/SmartCMPTests/Utils/CMPBitUtilsTest.swift
@@ -12,7 +12,7 @@
 import XCTest
 @testable import SmartCMP
 
-class CMPBitUtilsTests : XCTestCase {
+class CMPBitUtilsTests: XCTestCase {
     
     private func date(from string: String) -> Date {
         let formatter = DateFormatter()

--- a/framework/SmartCMPTests/VendorList/CMPFeatureTests.swift
+++ b/framework/SmartCMPTests/VendorList/CMPFeatureTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 @testable import SmartCMP
 
-class CMPFeatureTests : XCTestCase {
+class CMPFeatureTests: XCTestCase {
     
     func testFeatureIsEquatable() {
         let feature1 = CMPFeature(id: 1, name: "name1", description: "description1")

--- a/framework/SmartCMPTests/VendorList/CMPPurposeTests.swift
+++ b/framework/SmartCMPTests/VendorList/CMPPurposeTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 @testable import SmartCMP
 
-class CMPPurposeTests : XCTestCase {
+class CMPPurposeTests: XCTestCase {
     
     func testPurposeIsEquatable() {
         let purpose1 = CMPPurpose(id: 1, name: "name1", description: "description1")

--- a/framework/SmartCMPTests/VendorList/CMPVendorListManagerTests.swift
+++ b/framework/SmartCMPTests/VendorList/CMPVendorListManagerTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 @testable import SmartCMP
 
-class CMPVendorListManagerTests : XCTestCase {
+class CMPVendorListManagerTests: XCTestCase {
     
     private lazy var vendorListJSON: String = {
         let url = Bundle(for: type(of: self)).url(forResource: "vendors", withExtension: "json")!

--- a/framework/SmartCMPTests/VendorList/CMPVendorListTests.swift
+++ b/framework/SmartCMPTests/VendorList/CMPVendorListTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 @testable import SmartCMP
 
-class CMPVendorListTests : XCTestCase {
+class CMPVendorListTests: XCTestCase {
     
     private func date(from string: String) -> Date {
         let formatter = DateFormatter()

--- a/framework/SmartCMPTests/VendorList/CMPVendorListURLTests.swift
+++ b/framework/SmartCMPTests/VendorList/CMPVendorListURLTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 @testable import SmartCMP
 
-class CMPVendorListURLTests : XCTestCase {
+class CMPVendorListURLTests: XCTestCase {
     
     func testDefaultVendorListURLCorrespondsToTheLatest() {
         let expectedUrl = URL(string: "https://vendorlist.consensu.org/vendorlist.json")!

--- a/framework/SmartCMPTests/VendorList/CMPVendorTests.swift
+++ b/framework/SmartCMPTests/VendorList/CMPVendorTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 @testable import SmartCMP
 
-class CMPVendorTests : XCTestCase {
+class CMPVendorTests: XCTestCase {
     
     func testVendorIsEquatable() {
         let vendor1 = CMPVendor(id: 1, name: "name1", purposes: [1], legitimatePurposes: [2], features: [3], policyURL: URL(string: "http://url1")!)


### PR DESCRIPTION
Some third party SDK don't handle the IAB consent string, but use instead a binary _(aka 'yes/no')_ consent, only for the advertising purpose.
This PR defines a new _NSUserDefaults_ key that will be updated by _SmartCMP_ and that stores a binary consent (for advertising only). This key could then be used for these third party SDK.

_Note: this behavior is not part of the IAB specification and should only be used for third party SDK that don't handle the IAB consent string._