### PR TITLE
Added a public API to allow or remove all purposes consents

### DIFF
--- a/demo/SmartCMPDemo/AppDelegate.swift
+++ b/demo/SmartCMPDemo/AppDelegate.swift
@@ -45,6 +45,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CMPConsentManagerDelegate
     func consentManagerRequestsToShowConsentTool(_ consentManager: CMPConsentManager, forVendorList vendorList: CMPVendorList) {
         NSLog("CMP Requested ConsentTool Display");
         
+        // ---------------------------------------------------------------------------------------------------------------------
+        
         // You should display the consent tool UI, when user is ready…
         if let controller = self.window?.rootViewController {
             let _ = consentManager.showConsentTool(fromController: controller)
@@ -55,6 +57,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CMPConsentManagerDelegate
         // more details about this).
         //
         // To generate a valid IAB consent string easily, you can use the CMPConsentString class.
+        
+        // ---------------------------------------------------------------------------------------------------------------------
+        
+        // Note: depending on the situation, you might also want to allow or revoke all purposes consents without showing
+        // the consent tool. You can do it using the allowAllPurposes() and revokeAllPurposes() methods.
+        
+        // Allow all purposes consents without prompting the user, for instance if the user is not subject to GDPR (for instance,
+        // when he is living outside of the EU).
+        // let _ = consentManager.allowAllPurposes()
+        
+        // Revoke all purposes consents without prompting the user, for instance if the user is under 16 years old (or younger
+        // depending on the country where the user is located).
+        // let _ = consentManager.revokeAllPurposes()
     }
     
     // MARK: - Consent Tool Configuration

--- a/framework/SmartCMP/ConsentString/CMPConsentString+Utils.swift
+++ b/framework/SmartCMP/ConsentString/CMPConsentString+Utils.swift
@@ -263,4 +263,82 @@ internal extension CMPConsentString {
         )
     }
     
+    /**
+     Return a new consent string identical to the one provided in parameters, with all purposed disallowed.
+     
+     Note: the vendor list provided must match the one used to generate the previous consent string, otherwise
+     this method will return nil.
+     
+     - Parameters:
+        - previousConsentString: The previous consent string.
+        - consentScreen: The screen number in the CMP where the consent was given.
+        - consentLanguage: The language that the CMP asked for consent in.
+        - vendorList: The vendor list corresponding to the consent string.
+        - lastUpdated: The date that will be used as last updated date (optional, it will use the current date by default).
+     - Returns: A new consent string identical to the one provided in parameters with all purposed disallowed if possible, nil otherwise.
+     */
+    static func consentStringWithNoPurposesConsent(fromConsentString previousConsentString: CMPConsentString,
+                                                   consentScreen: Int,
+                                                   consentLanguage: CMPLanguage,
+                                                   vendorList: CMPVendorList,
+                                                   lastUpdated: Date = Date()) -> CMPConsentString? {
+        
+        guard previousConsentString.vendorListVersion == vendorList.vendorListVersion else {
+            return nil
+        }
+        
+        return CMPConsentString(
+            versionConfig: CMPVersionConfig.LATEST,
+            created: previousConsentString.created,
+            lastUpdated: lastUpdated,
+            cmpId: CMPConstants.CMPInfos.ID,
+            cmpVersion: CMPConstants.CMPInfos.VERSION,
+            consentScreen: consentScreen,
+            consentLanguage: consentLanguage,
+            allowedPurposes: [], // No purpose allowed
+            allowedVendors: previousConsentString.allowedVendors,
+            vendorList: vendorList
+        )
+    }
+    
+    /**
+     Return a new consent string identical to the one provided in parameters, with all purposed allowed.
+     
+     Note: the vendor list provided must match the one used to generate the previous consent string, otherwise
+     this method will return nil.
+     
+     - Parameters:
+        - previousConsentString: The previous consent string.
+        - consentScreen: The screen number in the CMP where the consent was given.
+        - consentLanguage: The language that the CMP asked for consent in.
+        - vendorList: The vendor list corresponding to the consent string.
+        - lastUpdated: The date that will be used as last updated date (optional, it will use the current date by default).
+     - Returns: A new consent string identical to the one provided in parameters with all purposed allowed if possible, nil otherwise.
+     */
+    static func consentStringWithAllPurposesConsent(fromConsentString previousConsentString: CMPConsentString,
+                                                    consentScreen: Int,
+                                                    consentLanguage: CMPLanguage,
+                                                    vendorList: CMPVendorList,
+                                                    lastUpdated: Date = Date()) -> CMPConsentString? {
+        
+        guard previousConsentString.vendorListVersion == vendorList.vendorListVersion else {
+            return nil
+        }
+        
+        let allowedPurposes = IndexSet(vendorList.purposes.map { $0.id })
+        
+        return CMPConsentString(
+            versionConfig: CMPVersionConfig.LATEST,
+            created: previousConsentString.created,
+            lastUpdated: lastUpdated,
+            cmpId: CMPConstants.CMPInfos.ID,
+            cmpVersion: CMPConstants.CMPInfos.VERSION,
+            consentScreen: consentScreen,
+            consentLanguage: consentLanguage,
+            allowedPurposes: allowedPurposes,
+            allowedVendors: previousConsentString.allowedVendors,
+            vendorList: vendorList
+        )
+    }
+    
 }

--- a/framework/SmartCMP/Manager/CMPConsentManager.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManager.swift
@@ -208,6 +208,76 @@ public class CMPConsentManager: NSObject, CMPVendorListManagerDelegate, CMPConse
         return true
     }
     
+    /**
+     Add all purposes consents for the current consent string if it is already defined, create a new consent string with full consent otherwise.
+     
+     - Returns: true if the modification has been done successfully, false otherwise.
+     */
+    @objc
+    public func allowAllPurposes() -> Bool {
+        // Log error and stop if configuration is not made
+        guard self.configured else {
+            logErrorMessage("CMPConsentManager is not configured for this session. Please call CMPConsentManager.shared.configure() first.")
+            return false;
+        }
+        
+        guard let lastVendorList = self.lastVendorList else {
+            logErrorMessage("Purposes can't be modified because the vendor list is not available or up-to-date.")
+            return false;
+        }
+        
+        let newConsentString: CMPConsentString? = {
+            if let consentString = self.consentString {
+                return CMPConsentString.consentStringWithAllPurposesConsent(fromConsentString: consentString, consentScreen: 0, consentLanguage: language, vendorList: lastVendorList)
+            } else {
+                return CMPConsentString.consentStringWithFullConsent(consentScreen: 0, consentLanguage: language, vendorList: lastVendorList)
+            }
+        }()
+        
+        guard newConsentString != nil else {
+            logErrorMessage("Purposes can't be modified because the vendor list is not available or up-to-date.")
+            return false
+        }
+        
+        self.consentString = newConsentString
+        return true
+    }
+    
+    /**
+     Remove all purposes consents for the current consent string if it is already defined, create a new consent string with full vendors consent and no purposes consent otherwise.
+     
+     - Returns: true if the modification has been done successfully, false otherwise.
+     */
+    @objc
+    public func revokeAllPurposes() -> Bool {
+        // Log error and stop if configuration is not made
+        guard self.configured else {
+            logErrorMessage("CMPConsentManager is not configured for this session. Please call CMPConsentManager.shared.configure() first.")
+            return false;
+        }
+        
+        guard let lastVendorList = self.lastVendorList else {
+            logErrorMessage("Purposes can't be modified because the vendor list is not available or up-to-date.")
+            return false;
+        }
+        
+        let newConsentString: CMPConsentString? = {
+            if let consentString = self.consentString {
+                return CMPConsentString.consentStringWithNoPurposesConsent(fromConsentString: consentString, consentScreen: 0, consentLanguage: language, vendorList: lastVendorList)
+            } else {
+                return CMPConsentString.consentStringWithNoConsent(consentScreen: 0, consentLanguage: language, vendorList: lastVendorList)
+            }
+        }()
+        
+        guard newConsentString != nil else {
+            logErrorMessage("Purposes can't be modified because the vendor list is not available or up-to-date.")
+            return false
+        }
+        
+        self.consentString = newConsentString
+        return true
+    }
+    
     // MARK: - Automatic vendor list monitoring management
     
     /**

--- a/framework/SmartCMPTests/ConsentString/CMPConsentStringTests.swift
+++ b/framework/SmartCMPTests/ConsentString/CMPConsentStringTests.swift
@@ -678,4 +678,126 @@ class CMPConsentStringTests: XCTestCase {
         XCTAssertEqual(idExistsConsentString, expectedConsentString2)
     }
     
+    func testConsentStringFromConsentStringWithNoPurposeConsent() {
+        let date = self.date(from: "2017-11-07T18:59:04.9Z")
+        let updatedDate = self.date(from: "2018-11-07T18:59:04.9Z")
+        
+        let consentString = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
+                                             created: date,
+                                             lastUpdated: date,
+                                             cmpId: 1,
+                                             cmpVersion: 2,
+                                             consentScreen: 3,
+                                             consentLanguage: CMPLanguage(string: "en")!,
+                                             allowedPurposes: [1, 2],
+                                             allowedVendors: [1, 2, 4],
+                                             vendorList: vendorList)
+        
+        let expectedConsentString = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
+                                                     created: date,
+                                                     lastUpdated: updatedDate,
+                                                     cmpId: CMPConstants.CMPInfos.ID,
+                                                     cmpVersion: CMPConstants.CMPInfos.VERSION,
+                                                     consentScreen: 4,
+                                                     consentLanguage: CMPLanguage(string: "fr")!,
+                                                     allowedPurposes: [],
+                                                     allowedVendors: [1, 2, 4],
+                                                     vendorList: vendorList)
+        
+        let resultConsentString = CMPConsentString.consentStringWithNoPurposesConsent(fromConsentString: consentString,
+                                                                                      consentScreen: 4,
+                                                                                      consentLanguage: CMPLanguage(string: "fr")!,
+                                                                                      vendorList: vendorList,
+                                                                                      lastUpdated: updatedDate)
+        
+        XCTAssertEqual(resultConsentString, expectedConsentString)
+    }
+    
+    func testConsentStringFromConsentStringWithNoPurposeConsentFailsIfVendorListVersionDiffers() {
+        let date = self.date(from: "2017-11-07T18:59:04.9Z")
+        let updatedDate = self.date(from: "2018-11-07T18:59:04.9Z")
+        
+        let consentString = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
+                                             created: date,
+                                             lastUpdated: date,
+                                             cmpId: 1,
+                                             cmpVersion: 2,
+                                             consentScreen: 3,
+                                             consentLanguage: CMPLanguage(string: "en")!,
+                                             allowedPurposes: [1, 2],
+                                             allowedVendors: [1, 2, 4],
+                                             vendorList: vendorList)
+        
+        let expectedConsentString: CMPConsentString? = nil
+        
+        let resultConsentString = CMPConsentString.consentStringWithNoPurposesConsent(fromConsentString: consentString,
+                                                                                      consentScreen: 4,
+                                                                                      consentLanguage: CMPLanguage(string: "fr")!,
+                                                                                      vendorList: updatedVendorList,
+                                                                                      lastUpdated: updatedDate)
+        
+        XCTAssertEqual(resultConsentString, expectedConsentString)
+    }
+    
+    func testConsentStringFromConsentStringWithAllPurposeConsent() {
+        let date = self.date(from: "2017-11-07T18:59:04.9Z")
+        let updatedDate = self.date(from: "2018-11-07T18:59:04.9Z")
+        
+        let consentString = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
+                                             created: date,
+                                             lastUpdated: date,
+                                             cmpId: 1,
+                                             cmpVersion: 2,
+                                             consentScreen: 3,
+                                             consentLanguage: CMPLanguage(string: "en")!,
+                                             allowedPurposes: [1, 2],
+                                             allowedVendors: [1, 2, 4],
+                                             vendorList: vendorList)
+        
+        let expectedConsentString = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
+                                                     created: date,
+                                                     lastUpdated: updatedDate,
+                                                     cmpId: CMPConstants.CMPInfos.ID,
+                                                     cmpVersion: CMPConstants.CMPInfos.VERSION,
+                                                     consentScreen: 4,
+                                                     consentLanguage: CMPLanguage(string: "fr")!,
+                                                     allowedPurposes: [1, 2, 3, 4, 5],
+                                                     allowedVendors: [1, 2, 4],
+                                                     vendorList: vendorList)
+        
+        let resultConsentString = CMPConsentString.consentStringWithAllPurposesConsent(fromConsentString: consentString,
+                                                                                       consentScreen: 4,
+                                                                                       consentLanguage: CMPLanguage(string: "fr")!,
+                                                                                       vendorList: vendorList,
+                                                                                       lastUpdated: updatedDate)
+        
+        XCTAssertEqual(resultConsentString, expectedConsentString)
+    }
+    
+    func testConsentStringFromConsentStringWithAllPurposeConsentFailsIfVendorListVersionDiffers() {
+        let date = self.date(from: "2017-11-07T18:59:04.9Z")
+        let updatedDate = self.date(from: "2018-11-07T18:59:04.9Z")
+        
+        let consentString = CMPConsentString(versionConfig: CMPVersionConfig(version: 1)!,
+                                             created: date,
+                                             lastUpdated: date,
+                                             cmpId: 1,
+                                             cmpVersion: 2,
+                                             consentScreen: 3,
+                                             consentLanguage: CMPLanguage(string: "en")!,
+                                             allowedPurposes: [1, 2],
+                                             allowedVendors: [1, 2, 4],
+                                             vendorList: vendorList)
+        
+        let expectedConsentString: CMPConsentString? = nil
+        
+        let resultConsentString = CMPConsentString.consentStringWithAllPurposesConsent(fromConsentString: consentString,
+                                                                                       consentScreen: 4,
+                                                                                       consentLanguage: CMPLanguage(string: "fr")!,
+                                                                                       vendorList: updatedVendorList,
+                                                                                       lastUpdated: updatedDate)
+        
+        XCTAssertEqual(resultConsentString, expectedConsentString)
+    }
+    
 }


### PR DESCRIPTION
In some cases (underage user, non European user, etc…), the app developer might want to avoid displaying the consent tool to set the consent string and instead allow or revoke all purposes consents by default.

This PR adds two methods to do it easily (and adds a sample implementation in the demo app).