### PR TITLE
Fixed a potential crash when parsing invalid consent strings

### DIFF
--- a/framework/SmartCMP/ConsentString/CMPConsentString.swift
+++ b/framework/SmartCMP/ConsentString/CMPConsentString.swift
@@ -14,7 +14,8 @@ import Foundation
 /**
  Representation of an IAB consent string.
  */
-@objc public class CMPConsentString: NSObject, NSCopying {
+@objc
+public class CMPConsentString: NSObject, NSCopying {
     
     /// The type of encoding of the consent string.
     internal enum ConsentEncoding {

--- a/framework/SmartCMP/Utils/CMPBitUtils.swift
+++ b/framework/SmartCMP/Utils/CMPBitUtils.swift
@@ -136,7 +136,8 @@ internal class CMPBitUtils {
      */
     public static func bitsToLetter(_ bits: String) -> String? {
         if let letterIndex = bitsToInt(bits) {
-            return CMPLanguage.VALID_LETTERS[letterIndex]
+            // Checking if the index correspond to a valid letter
+            return letterIndex < CMPLanguage.VALID_LETTERS.count ? CMPLanguage.VALID_LETTERS[letterIndex] : nil
         } else {
             return nil
         }

--- a/framework/SmartCMPTests/Utils/CMPBitUtilsTest.swift
+++ b/framework/SmartCMPTests/Utils/CMPBitUtilsTest.swift
@@ -82,6 +82,7 @@ class CMPBitUtilsTests: XCTestCase {
     }
     
     func testBitsToLetter() {
+        // Valid letters
         XCTAssertEqual(CMPBitUtils.bitsToLetter("0"), "a")
         XCTAssertEqual(CMPBitUtils.bitsToLetter("1010"), "k")
         XCTAssertEqual(CMPBitUtils.bitsToLetter("11001"), "z")
@@ -90,6 +91,10 @@ class CMPBitUtilsTests: XCTestCase {
         XCTAssertEqual(CMPBitUtils.bitsToLetter("011001"), "z")
         XCTAssertNil(CMPBitUtils.bitsToLetter(""))
         XCTAssertNil(CMPBitUtils.bitsToLetter("a"))
+        
+        // Valid integers, but invalid letters
+        XCTAssertNil(CMPBitUtils.bitsToLetter("011010"))
+        XCTAssertNil(CMPBitUtils.bitsToLetter("111111"))
     }
     
     func testBitsToLanguage() {


### PR DESCRIPTION
An invalid consent string containing 'letters' represented by a number greater than the number of letters in the alphabet will crash the app.

This PR fixes this issue and adds an unit test to validates the new behavior.