### PR TITLE
Match strings with IAB API

### DIFF
--- a/framework/SmartCMP/CMPConstants.swift
+++ b/framework/SmartCMP/CMPConstants.swift
@@ -32,8 +32,8 @@ internal struct CMPConstants {
         static let CMPPresent                       = "IABConsent_CMPPresent"
         static let SubjectToGDPR                    = "IABConsent_SubjectToGDPR"
         static let ConsentString                    = "IABConsent_ConsentString"
-        static let ParsedPurposeConsent             = "IABConsent_ParsedPurposeConsent"
-        static let ParsedVendorConsent              = "IABConsent_ParsedVendorConsent"
+        static let ParsedPurposeConsent             = "IABConsent_ParsedPurposeConsents"
+        static let ParsedVendorConsent              = "IABConsent_ParsedVendorConsents"
     }
     
     /// The AdvertisingConsentStatus NSUserDefaults key contains the current user consent for the advertising


### PR DESCRIPTION
[Mobile In-App CMP API v1.0: Transparency & Consent Framework](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Mobile%20In-App%20Consent%20APIs%20v1.0%20Draft%20for%20Public%20Comment.md#structure)

Two strings didn't match with API Specifications
