### PR TITLE
The consent string property on CMPConsentManager is now private.

### DIFF
--- a/framework/SmartCMP/Manager/CMPConsentManager.swift
+++ b/framework/SmartCMP/Manager/CMPConsentManager.swift
@@ -35,8 +35,7 @@ public class CMPConsentManager: NSObject, CMPVendorListManagerDelegate, CMPConse
     public var subjectToGDPR: Bool = false { didSet { gdrpStatusChanged() } }
     
     /// The consent string.
-    @objc
-    public var consentString: CMPConsentString? { didSet { consentStringChanged() } }
+    private var consentString: CMPConsentString? { didSet { consentStringChanged() } }
     
     // MARK: - Private fields
     


### PR DESCRIPTION
Users should load the consent string from NSUserDefaults instead, as recommended by the IAB.

Fix <https://github.com/smartadserver/smart-gdpr-cmp-ios/issues/24>.