### PR TITLE
Solve memory issues

### DIFF
--- a/framework/SmartCMP/UI/CMPConsentToolManager.swift
+++ b/framework/SmartCMP/UI/CMPConsentToolManager.swift
@@ -34,7 +34,7 @@ internal class CMPConsentToolManager {
     private let vendorList: CMPVendorList
     
     /// Current view controller.
-    private var presentingViewController: UIViewController?
+    private weak var presentingViewController: UIViewController?
     
     /// Consent tool configuration.
     internal let configuration: CMPConsentToolConfiguration
@@ -99,12 +99,14 @@ internal class CMPConsentToolManager {
      - Parameter save: true if the current consent string must be saved, false if it needs to be discarded.
      */
     func dismissConsentTool(save: Bool) {
-        guard let viewController = self.presentingViewController else {
-            return;
+        let completion: () -> Void = {
+            self.delegate?.consentToolManager(self, didFinishWithConsentString: save ? self.generatedConsentString : self.initialConsentString)
         }
         
-        viewController.dismiss(animated: true) {
-            self.delegate?.consentToolManager(self, didFinishWithConsentString: save ? self.generatedConsentString : self.initialConsentString)
+        if let viewController = self.presentingViewController {
+            viewController.dismiss(animated: true, completion: completion)
+        } else {
+            completion()
         }
     }
     

--- a/framework/SmartCMP/VendorList/CMPVendorListManager.swift
+++ b/framework/SmartCMP/VendorList/CMPVendorListManager.swift
@@ -44,7 +44,7 @@ internal class CMPVendorListManager {
     let pollInterval: TimeInterval
     
     /// The delegate that should be warned when a vendor list is available or in case of errors.
-    let delegate: CMPVendorListManagerDelegate
+    weak var delegate: CMPVendorListManagerDelegate?
     
     /// The URL session used for network connection.
     ///
@@ -274,11 +274,11 @@ internal class CMPVendorListManager {
     private func callRefreshCallback(vendorList: CMPVendorList?, error: Error?, responseHandler: ((CMPVendorList?, Error?) -> ())?) {
         if let handler = responseHandler {
             handler(vendorList, error)
-        } else {
+        } else if let delegate = self.delegate {
             if let vendorList = vendorList {
-                self.delegate.vendorListManager(self, didFetchVendorList: vendorList)
+                delegate.vendorListManager(self, didFetchVendorList: vendorList)
             } else if let error = error {
-                self.delegate.vendorListManager(self, didFailWithError: error)
+                delegate.vendorListManager(self, didFailWithError: error)
             }
         }
     }

--- a/framework/SmartCMP/VendorList/CMPVendorListManagerDelegate.swift
+++ b/framework/SmartCMP/VendorList/CMPVendorListManagerDelegate.swift
@@ -14,7 +14,7 @@ import Foundation
 /**
  Delegate of CMPVendorListManager.
  */
-internal protocol CMPVendorListManagerDelegate {
+internal protocol CMPVendorListManagerDelegate: class {
     
     /**
      Method called when the vendor list manager did fetch a vendor list successfully.


### PR DESCRIPTION
While integrating the library I noticed two memory related issues:

1. The first one is represented by the fact that `CMPConsentToolManager` holds a strong reference to `presentingViewController`. This leads to `presentingViewController` remaining in memory even after its dismissal. (solved by 0b03e83)
2. The second one is a retain cycle between `CMPConsentToolManager` and `CMPVendorListManager`, caused by the fact that the latter holds a strong reference to its delegate object. (solved by f85e69a)