### PR TITLE
Fixed crash on 32 bits devices

### DIFF
--- a/framework/SmartCMP/Utils/CMPBitUtils.swift
+++ b/framework/SmartCMP/Utils/CMPBitUtils.swift
@@ -29,12 +29,7 @@ internal class CMPBitUtils {
      - Returns: A string encoded integer.
      */
     public static func intToBits(_ number: Int, numberOfBits: Int) -> String {
-        precondition(number >= 0, "'number' must be positive")
-        precondition(numberOfBits >= 0, "'numberOfBits' must be positive")
-        
-        let bits = String(number, radix: 2)
-        let padding = numberOfBits - bits.count
-        return padding > 0 ? bits.leftPadded(count: padding) : bits
+        return int64ToBits(Int64(number), numberOfBits: numberOfBits)
     }
     
     /**
@@ -45,6 +40,41 @@ internal class CMPBitUtils {
      */
     public static func bitsToInt(_ bits: String) -> Int? {
         return Int(bits, radix: 2)
+    }
+    
+    /**
+     Encode a 64 bits integer into a bit string.
+     
+     This method should be used only for numbers that could overflow a 32 bits integer
+     on older iOS devices, like deciseconds encoding.
+     
+     - Parameters:
+         - number: The integer that needs to be encoded.
+         - numberOfBits: The minimum length of the returned string.
+     - Precondition: number must be a positive number (or equals to 0).
+     - Precondition: numberOfBits must be a positive number (or equals to 0).
+     - Returns: A string encoded integer.
+     */
+    public static func int64ToBits(_ number: Int64, numberOfBits: Int) -> String {
+        precondition(number >= 0, "'number' must be positive")
+        precondition(numberOfBits >= 0, "'numberOfBits' must be positive")
+        
+        let bits = String(number, radix: 2)
+        let padding = numberOfBits - bits.count
+        return padding > 0 ? bits.leftPadded(count: padding) : bits
+    }
+    
+    /**
+     Decode an 64 bits int from a bit string.
+     
+     This method should be used only for numbers that could overflow a 32 bits integer
+     on older iOS devices, like deciseconds decoding.
+     
+     - Parameter bits: The bit string that must be decoded.
+     - Returns: An integer if bits are valid, nil otherwise.
+     */
+    public static func bitsToInt64(_ bits: String) -> Int64? {
+        return Int64(bits, radix: 2)
     }
     
     /**

--- a/framework/SmartCMP/Utils/CMPBitUtils.swift
+++ b/framework/SmartCMP/Utils/CMPBitUtils.swift
@@ -124,7 +124,7 @@ internal class CMPBitUtils {
         precondition(numberOfBits >= 0, "'numberOfBits' must be positive")
         
         let deciseconds = date.timeIntervalSince1970 * 10
-        return intToBits(Int(deciseconds.rounded()), numberOfBits: numberOfBits)
+        return int64ToBits(Int64(deciseconds.rounded()), numberOfBits: numberOfBits)
     }
     
     /**
@@ -134,7 +134,7 @@ internal class CMPBitUtils {
      - Returns: A date if bits are valid, nil otherwise.
      */
     public static func bitsToDate(_ bits: String) -> Date? {
-        if let deciseconds = bitsToInt(bits) {
+        if let deciseconds = bitsToInt64(bits) {
             return Date(timeIntervalSince1970: Double(deciseconds) / 10.0)
         } else {
             return nil

--- a/framework/SmartCMPTests/Utils/CMPBitUtilsTest.swift
+++ b/framework/SmartCMPTests/Utils/CMPBitUtilsTest.swift
@@ -29,6 +29,11 @@ class CMPBitUtilsTests: XCTestCase {
         XCTAssertEqual(CMPBitUtils.intToBits(42, numberOfBits: 8), "00101010")
     }
     
+    func testInt64ToBits() {
+        XCTAssertEqual(CMPBitUtils.int64ToBits(10_000_000_000, numberOfBits: 1), "1001010100000010111110010000000000")
+        XCTAssertEqual(CMPBitUtils.int64ToBits(10_000_000_000, numberOfBits: 40), "0000001001010100000010111110010000000000")
+    }
+    
     func testBoolToBits() {
         XCTAssertEqual(CMPBitUtils.boolToBits(false, numberOfBits: 1), "0")
         XCTAssertEqual(CMPBitUtils.boolToBits(true, numberOfBits: 1), "1")
@@ -64,6 +69,11 @@ class CMPBitUtilsTests: XCTestCase {
         XCTAssertEqual(CMPBitUtils.bitsToInt("10"), 2)
         XCTAssertEqual(CMPBitUtils.bitsToInt("00101010"), 42)
         XCTAssertNil(CMPBitUtils.bitsToInt("00101a10"))
+    }
+    
+    func testBitsToInt64() {
+        XCTAssertEqual(CMPBitUtils.bitsToInt("1001010100000010111110010000000000"), 10_000_000_000)
+        XCTAssertEqual(CMPBitUtils.bitsToInt("0000001001010100000010111110010000000000"), 10_000_000_000)
     }
     
     func testBitsToBool() {


### PR DESCRIPTION
When generating a bitstring, the date encoding will crash a 32 bits device because the deciseconds cannot fit in 32 bits. #33 

This PR fixes the crashes by using 64 bits integer for this operation no matter the device used to run the CMP.